### PR TITLE
Fix integration tests and apply latest Node and PhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ git clone https://github.com/Rise-Vision/widget-video.git
 
 If you want to get up and running quickly without having to install npm, Bower and Gulp, then you can make your code changes directly to the files in the `dist` folder. Please keep in mind that by doing so, you won't be able to take advantage of the many benefits that these tools provide, such as managing dependencies and running automated tests & builds. Should you decide that you would like to use these tools, you will first need to install them:
 
-- [Node.js and npm](http://blog.nodeknockout.com/post/65463770933/how-to-install-node-js-and-npm)
+- [Node.js and npm](http://blog.nodeknockout.com/post/65463770933/how-to-install-node-js-and-npm) - Node 6.x.x or greater is required for this Widget
 - [Bower](http://bower.io/#install-bower) - To install Bower, run the following command in Terminal: `npm install -g bower`. Should you encounter any errors, try running the following command instead: `sudo npm install -g bower`.
 - [Gulp](https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md) - To install Gulp, run the following command in Terminal: `npm install -g gulp`. Should you encounter any errors, try running the following command instead: `sudo npm install -g gulp`.
 
 Next, perform these additional steps at the command line:
 ```
 cd widget-video
+npm install -g phantomjs
 npm install
 bower install
 gulp build

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,7 @@ dependencies:
     - if [ -z $(grep version package.json |grep -o '[0-9.]*') ]; then echo Version must be specified in package.json; exit 1; fi
     - if [[ ! -d $HOME/aws ]]; then curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && unzip awscli-bundle.zip && sudo ./awscli-bundle/install -i $HOME/aws; fi
     - npm install -g gulp
+    - npm install -g phantomjs
   post:
     - bower install
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 4.3.0
+    version: 6.9.1
   environment:
     awscli: $HOME/aws/bin/aws
 general:

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "gulp-usemin": "0.3.7",
     "gulp-util": "~2.2.17",
     "gulp-watch": "^0.6.8",
-    "phantomjs": "^1.9.7-9",
     "run-sequence": "^0.3.2",
     "web-component-tester": "*",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#1.7.0"

--- a/test/integration/storage-v1/messaging-file.html
+++ b/test/integration/storage-v1/messaging-file.html
@@ -27,7 +27,7 @@
 
 <script src="../../../src/components/widget-common/dist/config.js"></script>
 <script src="../../../src/components/widget-common/dist/common.js"></script>
-<script src="../../../../src/components/widget-common/dist/message.js"></script>
+<script src="../../../src/components/widget-common/dist/message.js"></script>
 <script src="../../../src/components/widget-common/dist/rise-cache.js"></script>
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>

--- a/test/integration/storage-v2/messaging-file.html
+++ b/test/integration/storage-v2/messaging-file.html
@@ -27,7 +27,7 @@
 
 <script src="../../../src/components/widget-common/dist/config.js"></script>
 <script src="../../../src/components/widget-common/dist/common.js"></script>
-<script src="../../../../src/components/widget-common/dist/message.js"></script>
+<script src="../../../src/components/widget-common/dist/message.js"></script>
 <script src="../../../src/components/widget-common/dist/rise-cache.js"></script>
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>


### PR DESCRIPTION
- Fixed incorrect source paths for a couple integration tests
- Forcing CCI to use latest Node version 6.9.1
- PhantomJS requires being a global package when used in Node 6.x.x, adding it as a pre install for CCI