### PR TITLE
Removed loadingSpinner

### DIFF
--- a/src/widget/css/video.css
+++ b/src/widget/css/video.css
@@ -51,7 +51,7 @@ body {
 
 /* Hide buffer spinner */
 .video-js .vjs-loading-spinner {
-  display: none;
+  display: none !important;
 }
 
 .vjs-nofull .vjs-fullscreen-control {

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -140,7 +140,23 @@ RiseVision.Video.PlayerVJS = function PlayerVJS( params, mode ) {
       _pause = 0;
     }
 
+    _removeLoadingSpinner();
+
     _playerInstance = videojs( "player", _getOptions(), _ready );
+  }
+
+
+  /*
+    Remove the loading spinner from the video js components list. It is not a well defined way to do that by the api.
+    it is more a of hack so it could break if they change something in the future.
+    See code here https://github.com/videojs/video.js/blob/f05a9271b831ad11c54f36bca1f6e1a822b15942/src/js/player.js#L2776
+   */
+  function _removeLoadingSpinner() {
+    var loadingSpinnerIndex = videojs.options.children.indexOf( "loadingSpinner" );
+
+    if ( loadingSpinnerIndex > -1 ) {
+      videojs.options.children.splice( loadingSpinnerIndex, 1 );
+    }
   }
 
   function pause() {

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -140,23 +140,21 @@ RiseVision.Video.PlayerVJS = function PlayerVJS( params, mode ) {
       _pause = 0;
     }
 
-    _removeLoadingSpinner();
 
     _playerInstance = videojs( "player", _getOptions(), _ready );
+
+    _removeLoadingSpinner();
+
   }
 
 
   /*
-    Remove the loading spinner from the video js components list. It is not a well defined way to do that by the api.
-    it is more a of hack so it could break if they change something in the future.
-    See code here https://github.com/videojs/video.js/blob/f05a9271b831ad11c54f36bca1f6e1a822b15942/src/js/player.js#L2776
+    Remove the loading spinner using video js api
    */
   function _removeLoadingSpinner() {
-    var loadingSpinnerIndex = videojs.options.children.indexOf( "loadingSpinner" );
+    var loadingSpinnerComponent = _playerInstance.getChild( "loadingSpinner" );
 
-    if ( loadingSpinnerIndex > -1 ) {
-      videojs.options.children.splice( loadingSpinnerIndex, 1 );
-    }
+    _playerInstance.removeChild( loadingSpinnerComponent );
   }
 
   function pause() {

--- a/test/integration/non-storage/file.html
+++ b/test/integration/non-storage/file.html
@@ -81,6 +81,10 @@
       test( "should add controls to video", function() {
         assert.isNotNull( document.querySelector("#player.vjs-controls-enabled") );
       } );
+
+      test( "should remove loading spinner", function() {
+        assert.isNull( document.querySelector("#player.vjs-loading-spinner") );
+      } );
     } );
 
     suite("Disable fullscreen", function() {

--- a/test/unit/widget/player-vjs-spec.js
+++ b/test/unit/widget/player-vjs-spec.js
@@ -27,6 +27,8 @@ var videoJSObj =
     return videoJSObj;
   };
 
+videojs.options = { children: [] };
+
 describe( "init()", function() {
   var params =
     {

--- a/test/unit/widget/player-vjs-spec.js
+++ b/test/unit/widget/player-vjs-spec.js
@@ -5,7 +5,8 @@
 
 "use strict";
 
-var videoJSObj =
+var loadSpinnerComponent,
+  videoJSObj =
   {
     src: function() {},
     options: function() {},
@@ -14,7 +15,11 @@ var videoJSObj =
     play: function() {},
     remainingTime: function() {},
     currentTime: function() {},
-    on: function() {}
+    on: function() {},
+    getChild: function() {
+      return loadSpinnerComponent
+    },
+    removeChild: function() {}
   },
   videojs = function( tag, opts, cb ) {
     videoJSObj.options( opts );
@@ -26,8 +31,6 @@ var videoJSObj =
 
     return videoJSObj;
   };
-
-videojs.options = { children: [] };
 
 describe( "init()", function() {
   var params =
@@ -47,10 +50,14 @@ describe( "init()", function() {
       "https://test.com/test%2Fvideos%2Fvideo1.webm"
     ],
     optionsSpy,
+    getChildSpy,
+    removeChildSpy,
     srcSpy;
 
   before( function() {
     optionsSpy = sinon.spy( videoJSObj, "options" );
+    getChildSpy = sinon.spy( videoJSObj, "getChild" );
+    removeChildSpy = sinon.spy( videoJSObj, "removeChild" );
     srcSpy = sinon.spy( videoJSObj, "src" );
   } );
 
@@ -70,6 +77,10 @@ describe( "init()", function() {
       height: params.height,
       width: params.width
     } );
+
+    expect( getChildSpy ).to.have.been.calledWith( "loadingSpinner" );
+
+    expect( removeChildSpy ).to.have.been.calledWith( loadSpinnerComponent );
 
     // delay for callback execution
     setTimeout( function() {


### PR DESCRIPTION
Changed css rule to use !important.
Removed the loadingSpinner from the videojs.options.children array. That will make it to not load the spinner component at all.

Fixed tests

@donnapep @stulees please review. cheers

Presentation here: http://rva.risevision.com/#/PRESENTATION_MANAGE/id=81b77624-9a58-43d6-9538-b497a0cdbf85?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013