### PR TITLE
Fixed scale to fit issue by reverting the use of fluid option [stage-4]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-video",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "homepage": "https://github.com/Rise-Vision/widget-video",
   "authors": [
     "Rise Vision"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-video",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "Rise Vision Video Widget",
   "main": "gulpfile.js",
   "scripts": {

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -31,7 +31,7 @@ RiseVision.Video.PlayerVJS = function PlayerVJS( params, mode ) {
   function _getOptions() {
     return {
       controls: params.video.controls,
-      fluid: params.video.scaleToFit,
+      fluid: !params.video.scaleToFit,
       height: params.height,
       width: params.width
     };

--- a/test/integration/js/logging-file.js
+++ b/test/integration/js/logging-file.js
@@ -15,7 +15,7 @@ var spy,
     "company_id": '"companyId"',
     "display_id": '"displayId"',
     /* eslint-enable quotes */
-    "version": "2.0.0"
+    "version": "1.1.0"
   },
   check = function( done ) {
     if ( ready ) {

--- a/test/integration/js/logging-folder.js
+++ b/test/integration/js/logging-folder.js
@@ -16,7 +16,7 @@ var playStub,
     "company_id": '"companyId"',
     "display_id": '"displayId"',
     /* eslint-enable quotes */
-    "version": "2.0.0"
+    "version": "1.1.0"
   },
   check = function( done ) {
     if ( ready ) {

--- a/test/integration/non-storage/logging.html
+++ b/test/integration/non-storage/logging.html
@@ -51,7 +51,7 @@
         "file_format": "webm",
         "company_id": '"companyId"',
         "display_id": '"displayId"',
-        "version": "2.0.0"
+        "version": "1.1.0"
       },
       paramsStub, ready = false;
 

--- a/test/unit/widget/player-vjs-spec.js
+++ b/test/unit/widget/player-vjs-spec.js
@@ -73,7 +73,7 @@ describe( "init()", function() {
 
     expect( optionsSpy ).to.have.been.calledWith( {
       controls: true,
-      fluid: true,
+      fluid: false,
       height: params.height,
       width: params.width
     } );


### PR DESCRIPTION
Updated tests

@donnapep @stulees I have talked to @alanclayton and we think that inverting the use of the fluid option will be a valid solution for us. So when scaling to fit option is true, fluid is going to be false. 

This is presentation showing a comparison with JWPlayer and also how it looks when the placeholder has the same size as the video. http://rva.risevision.com/#/PRESENTATION_MANAGE/id=9e4329da-8bb1-4c91-a531-97d62c71309a?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

Please review. cheers

@tejohnso @settinghead FYI.
