### PR TITLE
Handling "rise-cache-not-running" event to show message when running in player

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git#1.3.39",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.3.39",
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.13.0",
-    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#1.4.0",
+    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#1.4.2",
     "videojs": "5.11.9",
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.3.3",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#1.5.2",

--- a/src/widget/storage-file.js
+++ b/src/widget/storage-file.js
@@ -125,10 +125,24 @@ RiseVision.Video.StorageFile = function( data, displayId ) {
 
       var params = {
         "event": "rise cache not running",
-        "event_details": ( e.detail && e.detail.error ) ? e.detail.error.message : ""
+        "event_details": ""
       };
 
+      if ( e.detail ) {
+        if ( e.detail.error ) {
+          // storage v1
+          params.event_details = e.detail.error.message;
+        } else if ( e.detail.resp && e.detail.resp.error ) {
+          // storage v2
+          params.event_details = e.detail.resp.error.message;
+        }
+      }
+
       RiseVision.Video.logEvent( params, true );
+
+      if ( e.detail && e.detail.isPlayerRunning ) {
+        RiseVision.Video.showError( "Waiting for Rise Cache" );
+      }
     } );
 
     storage.addEventListener( "rise-cache-file-unavailable", function() {

--- a/src/widget/storage-folder.js
+++ b/src/widget/storage-folder.js
@@ -183,10 +183,24 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
 
       var params = {
         "event": "rise cache not running",
-        "event_details": ( e.detail && e.detail.error ) ? e.detail.error.message : ""
+        "event_details": ""
       };
 
+      if ( e.detail ) {
+        if ( e.detail.error ) {
+          // storage v1
+          params.event_details = e.detail.error.message;
+        } else if ( e.detail.resp && e.detail.resp.error ) {
+          // storage v2
+          params.event_details = e.detail.resp.error.message;
+        }
+      }
+
       RiseVision.Video.logEvent( params, true );
+
+      if ( e.detail && e.detail.isPlayerRunning ) {
+        RiseVision.Video.showError( "Waiting for Rise Cache" );
+      }
     } );
 
     storage.setAttribute( "fileType", "video" );

--- a/test/integration/js/file.js
+++ b/test/integration/js/file.js
@@ -249,6 +249,45 @@ suite( "Storage Errors", function() {
       "showError() called with correct message" );
   } );
 
+  test( "should handle when a 'rise cache not running' occurs", function() {
+    params.event = "rise cache not running";
+    params.event_details = "The request failed with status code: 404";
+
+    delete params.file_url;
+
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      assert( onShowErrorStub.calledOnce, "showError() called once" );
+      assert( onShowErrorStub.calledWith( "Waiting for Rise Cache" ),
+        "showError() called with correct message" );
+
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 404"
+          }
+        },
+        "bubbles": true
+      } ) );
+    }
+
+    assert( onLogEventStub.calledOnce, "logEvent() called once" );
+    assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
+
+  } );
+
 } );
 
 suite( "Network Recovery", function() {

--- a/test/integration/js/folder.js
+++ b/test/integration/js/folder.js
@@ -1,4 +1,4 @@
-/* global requests, suiteSetup, suite, suiteTeardown, test, assert, RiseVision, sinon, config */
+/* global requests, suiteSetup, suite, suiteTeardown, setup, teardown, test, assert, RiseVision, sinon, config */
 
 /* eslint-disable func-names */
 
@@ -235,4 +235,62 @@ suite( "Network Recovery", function() {
     RiseVision.Video.onFileRefresh.restore();
   } );
 
+} );
+
+suite( "storage errors", function() {
+  var params = { "event": "" },
+    onShowErrorStub,
+    onLogEventStub;
+
+  setup( function() {
+    onShowErrorStub = sinon.stub( RiseVision.Video, "showError", function() {} );
+    onLogEventStub = sinon.stub( RiseVision.Video, "logEvent", function() {} );
+  } );
+
+  teardown( function() {
+    delete params.url;
+    delete params.event_details;
+
+    RiseVision.Video.showError.restore();
+    RiseVision.Video.logEvent.restore();
+  } );
+
+  test( "should handle when a 'rise cache not running' occurs", function() {
+    params.event = "rise cache not running";
+    params.event_details = "The request failed with status code: 404";
+
+    delete params.file_url;
+
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      assert( onShowErrorStub.calledOnce, "showError() called once" );
+      assert( onShowErrorStub.calledWith( "Waiting for Rise Cache" ),
+        "showError() called with correct message" );
+
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 404"
+          }
+        },
+        "bubbles": true
+      } ) );
+    }
+
+    assert( onLogEventStub.calledOnce, "logEvent() called once" );
+    assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
+
+  } );
 } );

--- a/test/integration/js/logging-file.js
+++ b/test/integration/js/logging-file.js
@@ -184,7 +184,17 @@ suite( "rise storage error", function() {
   test( "should log a rise cache not running when ping response is empty", function() {
     spy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 
-    storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", null ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": null,
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", null ) );
+    }
 
     params.event = "rise cache not running";
     params.event_details = "";
@@ -196,14 +206,28 @@ suite( "rise storage error", function() {
   test( "should log a rise cache not running when ping response is 404", function() {
     spy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 
-    storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
-      "detail": {
-        "error": {
-          "message": "The request failed with status code: 404"
-        }
-      },
-      "bubbles": true
-    } ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 404"
+          }
+        },
+        "bubbles": true
+      } ) );
+    }
 
     params.event = "rise cache not running";
     params.event_details = "The request failed with status code: 404";

--- a/test/integration/js/logging-folder.js
+++ b/test/integration/js/logging-folder.js
@@ -206,7 +206,17 @@ suite( "rise storage error", function() {
   test( "should log a rise cache not running when ping response is empty", function() {
     spy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 
-    storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", null ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": null,
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", null ) );
+    }
 
     params.event = "rise cache not running";
     params.event_details = "";
@@ -218,14 +228,28 @@ suite( "rise storage error", function() {
   test( "should log a rise cache not running when ping response is 404", function() {
     spy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 
-    storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
-      "detail": {
-        "error": {
-          "message": "The request failed with status code: 404"
-        }
-      },
-      "bubbles": true
-    } ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 404"
+          }
+        },
+        "bubbles": true
+      } ) );
+    }
 
     params.event = "rise cache not running";
     params.event_details = "The request failed with status code: 404";

--- a/test/integration/js/messaging-file.js
+++ b/test/integration/js/messaging-file.js
@@ -245,3 +245,52 @@ suite( "cache file unavailable", function() {
     RiseVision.Video.play.restore();
   } );
 } );
+
+suite( "rise cache not running", function() {
+  test( "should show rise cache not running message using rise-storage v2", function() {
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      assert.equal( document.querySelector( ".message" ).innerHTML, "Waiting for Rise Cache", "message text" );
+      assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ), "message visibility" );
+    }
+  } );
+
+  test( "should call play function 5 seconds after a rise cache not running error using rise-storage v2", function() {
+    var clock = sinon.useFakeTimers(),
+      spy = sinon.spy( RiseVision.Video, "play" );
+
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      clock.tick( 4500 );
+      assert( spy.notCalled );
+      clock.tick( 500 );
+      assert( spy.calledOnce );
+
+      clock.restore();
+      RiseVision.Video.play.restore();
+    }
+
+  } );
+} );

--- a/test/integration/js/messaging-folder.js
+++ b/test/integration/js/messaging-folder.js
@@ -230,3 +230,52 @@ suite( "rise cache error", function() {
     RiseVision.Video.play.restore();
   } );
 } );
+
+suite( "rise cache not running", function() {
+  test( "should show rise cache not running message using rise-storage v2", function() {
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      assert.equal( document.querySelector( ".message" ).innerHTML, "Waiting for Rise Cache", "message text" );
+      assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ), "message visibility" );
+    }
+  } );
+
+  test( "should call play function 5 seconds after a rise cache not running error using rise-storage v2", function() {
+    var clock = sinon.useFakeTimers(),
+      spy = sinon.spy( RiseVision.Video, "play" );
+
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      clock.tick( 4500 );
+      assert( spy.notCalled );
+      clock.tick( 500 );
+      assert( spy.calledOnce );
+
+      clock.restore();
+      RiseVision.Video.play.restore();
+    }
+
+  } );
+} );


### PR DESCRIPTION
- Updating to use latest release of rise-storage v2 
- Conditionally populating `error_details` value in handler of `rise-storage` "rise cache not running" event based on `e.detail` object props
- Showing message "Waiting for Rise Cache" if `isPlayerRunning` present and `true` in handler of `rise-storage` "rise cache not running" event
- Added integration tests for file and folder scenarios