### PR TITLE
Revert rise-storage v2 version [stage-2]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git#1.3.39",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.3.39",
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.13.0",
-    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#1.4.2",
+    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#1.4.0",
     "videojs": "5.11.9",
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.4.2",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#1.5.2",


### PR DESCRIPTION
- The changes in 1.4.2 release of `rise-storage` component have not been fully validated, reverting to avoid issues