### PR TITLE
Resetting no matter where the video currently is

### DIFF
--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -209,10 +209,8 @@ RiseVision.Video.PlayerVJS = function PlayerVJS( params, mode ) {
   function reset() {
     pause();
 
-    // if video is at end, a future play call will start video over from beginning automatically
-    if ( _playerInstance.remainingTime() > 0 ) {
-      _playerInstance.currentTime( 0 );
-    }
+    // reset should always reset the video to the start
+    _playerInstance.currentTime( 0 );
   }
 
   function update( files ) {


### PR DESCRIPTION
The video is currently pausing at the last frame, causing a flash when the play is called again.
Also the current behaviour is not consistent on Windows and Linux, remainingTime was returning slightly different values.

@Rise-Vision/content @stulees please review