### PR TITLE
Hide video during seek

### DIFF
--- a/src/widget/css/video.css
+++ b/src/widget/css/video.css
@@ -58,6 +58,6 @@ body {
   display:none;
 }
 
-.vjs-ended .vjs-seeking {
+.vjs-user-inactive .vjs-seeking {
   display: none;
 }

--- a/src/widget/css/video.css
+++ b/src/widget/css/video.css
@@ -58,3 +58,6 @@ body {
   display:none;
 }
 
+.vjs-seeking {
+  display: none;
+}

--- a/src/widget/css/video.css
+++ b/src/widget/css/video.css
@@ -58,6 +58,6 @@ body {
   display:none;
 }
 
-.vjs-seeking {
+.vjs-ended .vjs-seeking {
   display: none;
 }

--- a/test/integration/non-storage/file.html
+++ b/test/integration/non-storage/file.html
@@ -138,6 +138,8 @@
       test( "should resume playing video after 5 seconds when paused", function( done ) {
         var video = document.getElementById( "player_html5_api" );
 
+        video.muted = true;
+        video.play();
         video.pause();
         clock.restore();
 


### PR DESCRIPTION
Hiding the video when it's seeking using CSS.
This way it won't flash the last frame when it starts back from the first frame.

I had to fix the test since Chrome 66 is not autoplaying videos unless it's muted.
Thanks.