### PR TITLE
Bump version for RLS work [stage-2]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-video",
-  "version": "1.1.0",
+  "version": "2.1.0",
   "homepage": "https://github.com/Rise-Vision/widget-video",
   "authors": [
     "Rise Vision"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-video",
-  "version": "1.1.0",
+  "version": "2.1.0",
   "description": "Rise Vision Video Widget",
   "main": "gulpfile.js",
   "scripts": {

--- a/test/integration/js/logging-file.js
+++ b/test/integration/js/logging-file.js
@@ -15,7 +15,7 @@ var spy,
     "company_id": '"companyId"',
     "display_id": '"displayId"',
     /* eslint-enable quotes */
-    "version": "1.1.0"
+    "version": "2.1.0"
   },
   check = function( done ) {
     if ( ready ) {

--- a/test/integration/js/logging-folder.js
+++ b/test/integration/js/logging-folder.js
@@ -16,7 +16,7 @@ var playStub,
     "company_id": '"companyId"',
     "display_id": '"displayId"',
     /* eslint-enable quotes */
-    "version": "1.1.0"
+    "version": "2.1.0"
   },
   check = function( done ) {
     if ( ready ) {

--- a/test/integration/non-storage/logging.html
+++ b/test/integration/non-storage/logging.html
@@ -51,7 +51,7 @@
         "file_format": "webm",
         "company_id": '"companyId"',
         "display_id": '"displayId"',
-        "version": "1.1.0"
+        "version": "2.1.0"
       },
       paramsStub, ready = false;
 


### PR DESCRIPTION
- Same as Image, plan is to bump version so we can eventually change Editor to start using new version and only impact new presentations while we monitor reliability and issues. Once stable, we will revert version back. 
- Also helps to initiate smaller incremental changes for PR reviews. 

@andrecardoso @santiagonoguez @tejohnso FYI