### PR TITLE
Prevent repetitive logging of file error from other widget instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-video",
-  "version": "2.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2297,7 +2297,7 @@
       "dev": true
     },
     "common-component": {
-      "version": "git://github.com/Rise-Vision/common-component.git#3c4b0d9ab40009abbfeb647cea690c1ec2fb6850",
+      "version": "git://github.com/Rise-Vision/common-component.git#bbe964a84295fd185a3bf6baddf2cb126c313b3d",
       "dev": true
     },
     "component-bind": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bower": "^1.5.3",
     "chai": "^2.1.2",
     "chai-as-promised": "^4.3.0",
-    "common-component": "git://github.com/Rise-Vision/common-component.git#v1.11.3",
+    "common-component": "git://github.com/Rise-Vision/common-component.git#v1.11.4",
     "del": "~1.1.1",
     "eslint": "^3.8.1",
     "eslint-config-idiomatic": "^2.1.0",

--- a/src/widget/player-local-storage-file.js
+++ b/src/widget/player-local-storage-file.js
@@ -1,4 +1,4 @@
-/* global localMessaging, playerLocalStorage */
+/* global localMessaging, playerLocalStorage, _ */
 /* eslint-disable no-console */
 
 var RiseVision = RiseVision || {};
@@ -15,7 +15,8 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
     storage = null,
     initialProcessingTimer = null,
     watchInitiated = false,
-    initialLoad = true;
+    initialLoad = true,
+    fileErrorLogParams = null;
 
   function _clearInitialProcessingTimer() {
     clearTimeout( initialProcessingTimer );
@@ -27,6 +28,10 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       // file is still processing/downloading
       RiseVision.VideoRLS.onFileUnavailable( "File is downloading" );
     }, INITIAL_PROCESSING_DELAY );
+  }
+
+  function _resetFileErrorLogParams() {
+    fileErrorLogParams = null;
   }
 
   function _handleNoConnection() {
@@ -68,6 +73,8 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
   }
 
   function _handleFileProcessing() {
+    _resetFileErrorLogParams();
+
     if ( initialLoad && !initialProcessingTimer ) {
       _startInitialProcessingTimer();
     }
@@ -75,6 +82,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
 
   function _handleFileAvailable( data ) {
     _clearInitialProcessingTimer();
+    _resetFileErrorLogParams();
 
     if ( initialLoad ) {
       initialLoad = false;
@@ -114,6 +122,12 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
         "file_url": filePath
       };
 
+    // prevent repetitive logging when widget is receiving messages from other potential widget instances watching same file
+    if ( _.isEqual( params, fileErrorLogParams ) ) {
+      return;
+    }
+
+    fileErrorLogParams = _.clone( params );
     videoUtils.logEvent( params, true );
 
     /*** Possible error messages from Local Storage ***/

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -10,7 +10,6 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     _files = null,
     _fileCount = 0,
     _utils = RiseVision.PlayerUtils,
-    _video = RiseVision.Video,
     _videoUtils = RiseVision.VideoUtils,
     _updateWaiting = false,
     _isPaused = false,
@@ -132,7 +131,7 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
   }
 
   function _setVolume() {
-    if ( _video.isInPreview() ) {
+    if ( !_videoUtils.isValidDisplayId() ) {
       _muteVideo();
       return;
     }

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -191,10 +191,11 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     pause();
   }
 
-  function setAdditionalParams( params, mode ) {
+  function setAdditionalParams( params, mode, displayId ) {
     var data = _.clone( params );
 
     _videoUtils.setMode( mode );
+    _videoUtils.setDisplayId( displayId );
     _videoUtils.setUseRLSSingleFile();
 
     document.getElementById( "container" ).style.width = _prefs.getInt( "rsW" ) + "px";

--- a/src/widget/video-utils.js
+++ b/src/widget/video-utils.js
@@ -9,6 +9,7 @@ RiseVision.VideoUtils = ( function() {
     _prefs = new gadgets.Prefs(),
     _currentFiles = [],
     _useRLSSingleFile = false,
+    _displayId = null,
     _params = null,
     _mode = null,
     _errorTimer = null;
@@ -36,6 +37,10 @@ RiseVision.VideoUtils = ( function() {
     return _currentFiles;
   }
 
+  function getDisplayId() {
+    return _displayId;
+  }
+
   function getMode() {
     return _mode;
   }
@@ -54,6 +59,10 @@ RiseVision.VideoUtils = ( function() {
     path += _params.storage.fileName;
 
     return "risemedialibrary-" + _params.storage.companyId + "/" + path;
+  }
+
+  function isValidDisplayId() {
+    return _displayId && _displayId !== "preview" && _displayId !== "display_id" && _displayId.indexOf( "displayId" ) === -1;
   }
 
   function isRLSSingleFile() {
@@ -110,6 +119,10 @@ RiseVision.VideoUtils = ( function() {
     }
   }
 
+  function setDisplayId( displayId ) {
+    _displayId = displayId;
+  }
+
   function setMode( mode ) {
     _mode = mode;
   }
@@ -125,16 +138,19 @@ RiseVision.VideoUtils = ( function() {
   return {
     "clearErrorTimer": clearErrorTimer,
     "getCurrentFiles": getCurrentFiles,
+    "getDisplayId": getDisplayId,
     "getMode": getMode,
     "getParams": getParams,
     "getTableName": getTableName,
     "getStorageSingleFilePath": getStorageSingleFilePath,
+    "isValidDisplayId": isValidDisplayId,
     "isRLSSingleFile": isRLSSingleFile,
     "logEvent": logEvent,
     "playerEnded": playerEnded,
     "sendDoneToViewer": sendDoneToViewer,
     "sendReadyToViewer": sendReadyToViewer,
     "setCurrentFiles": setCurrentFiles,
+    "setDisplayId": setDisplayId,
     "setMode": setMode,
     "setParams": setParams,
     "setUseRLSSingleFile": setUseRLSSingleFile,

--- a/src/widget/video.js
+++ b/src/widget/video.js
@@ -7,8 +7,7 @@ RiseVision.Video = {};
 RiseVision.Video = ( function( window, gadgets ) {
   "use strict";
 
-  var _displayId,
-    _isLoading = true,
+  var _isLoading = true,
     _configDetails = null,
     _videoUtils = RiseVision.VideoUtils,
     _prefs = new gadgets.Prefs(),
@@ -63,14 +62,14 @@ RiseVision.Video = ( function( window, gadgets ) {
           _configDetails = "storage file";
 
           // create and initialize the Storage file instance
-          _storage = new RiseVision.Video.StorageFile( params, _displayId );
+          _storage = new RiseVision.Video.StorageFile( params, _videoUtils.getDisplayId() );
           _storage.init();
         }
       } else if ( _videoUtils.getMode() === "folder" ) {
         _configDetails = "storage folder";
 
         // create and initialize the Storage folder instance
-        _storage = new RiseVision.Video.StorageFolder( params, _displayId );
+        _storage = new RiseVision.Video.StorageFolder( params, _videoUtils.getDisplayId() );
         _storage.init();
       }
     }
@@ -81,11 +80,6 @@ RiseVision.Video = ( function( window, gadgets ) {
   /*
    *  Public Methods
    */
-
-  function isInPreview() {
-    return !_displayId || _displayId === "preview" || _displayId === "display_id";
-  }
-
   function hasStorageError() {
     return _storageErrorFlag;
   }
@@ -204,7 +198,7 @@ RiseVision.Video = ( function( window, gadgets ) {
     var data = _.clone( params );
 
     _videoUtils.setMode( mode );
-    _displayId = displayId;
+    _videoUtils.setDisplayId( displayId );
 
     document.getElementById( "container" ).style.width = _prefs.getInt( "rsW" ) + "px";
     document.getElementById( "container" ).style.height = _prefs.getInt( "rsH" ) + "px";
@@ -262,7 +256,6 @@ RiseVision.Video = ( function( window, gadgets ) {
   }
 
   return {
-    "isInPreview": isInPreview,
     "hasPlayerError": hasPlayerError,
     "hasStorageError": hasStorageError,
     "onFileInit": onFileInit,

--- a/test/integration/js/player-local-storage-logging-file.js
+++ b/test/integration/js/player-local-storage-logging-file.js
@@ -170,6 +170,18 @@ suite( "errors", function() {
 
     assert( logSpy.calledOnce );
     assert( logSpy.calledWith( table, params ) );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-error",
+        filePath: params.file_url,
+        msg: "File's host server could not be reached",
+        detail: "error details"
+      } );
+    } );
+
+    // should still have only called it once from previous initial file error log
+    assert( logSpy.calledOnce );
   } );
 
   test( "file deleted", function() {

--- a/test/integration/js/player-local-storage-messaging-file.js
+++ b/test/integration/js/player-local-storage-messaging-file.js
@@ -109,19 +109,6 @@ suite( "errors", function() {
   } );
 
   test( "file error", function() {
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "file-error",
-        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
-        msg: "File's host server could not be reached",
-        detail: "error details"
-      } );
-    } );
-
-    assert.equal( document.querySelector( ".message" ).innerHTML, "Unable to download the file." );
-  } );
-
-  test( "should call done and have Viewer call play function 5 seconds after an error", function() {
     var clock = sinon.useFakeTimers(),
       spy = sinon.spy( RiseVision.VideoRLS, "play" );
 
@@ -133,6 +120,8 @@ suite( "errors", function() {
         detail: "error details"
       } );
     } );
+
+    assert.equal( document.querySelector( ".message" ).innerHTML, "Unable to download the file." );
 
     clock.tick( 4500 );
     assert( spy.notCalled );

--- a/test/integration/non-storage/file.html
+++ b/test/integration/non-storage/file.html
@@ -131,7 +131,7 @@
       test( "should set volume", function() {
         var video = document.getElementById( "player_html5_api" );
 
-        assert.equal( video.volume, 0.5 );
+        assert.equal( video.volume, 0 );
       } );
     } );
 


### PR DESCRIPTION
@jungeunyoon FYI the fix for 217 that was deployed broke the widget when configured for RLS single file. I've fixed/refactored it in this PR also, cheers.  