### PR TITLE
Downgrade "unauthorized" to a warning event [stage-2]

### DIFF
--- a/src/widget/player-local-storage-file.js
+++ b/src/widget/player-local-storage-file.js
@@ -56,7 +56,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
 
   function _handleUnauthorized() {
     videoUtils.logEvent( {
-      "event": "error",
+      "event": "warning",
       "event_details": "unauthorized",
       "file_url": filePath
     }, true );

--- a/test/integration/js/player-local-storage-logging-file.js
+++ b/test/integration/js/player-local-storage-logging-file.js
@@ -112,6 +112,7 @@ suite( "errors", function() {
       } );
     } );
 
+    params.event = "warning";
     params.event_details = "unauthorized";
 
     assert( logSpy.calledOnce );
@@ -147,6 +148,7 @@ suite( "errors", function() {
       } );
     } );
 
+    params.event = "error";
     params.event_details = "file does not exist";
 
     assert( logSpy.calledOnce );


### PR DESCRIPTION
- Widget should not have reliability impacted by a display being unauthorized for Storage 