### PR TITLE
Use RLS for storage folder

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.14.0",
     "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#2.1.0",
     "videojs": "5.11.9",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.5.1",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.6.2",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#v3.4.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
     "underscore": "~1.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2257,8 +2257,8 @@
       "optional": true
     },
     "common-component": {
-      "version": "git://github.com/Rise-Vision/common-component.git#114f0abf22fdf658fc1e3fe48a01e426bdc2f24f",
-      "from": "git://github.com/Rise-Vision/common-component.git#v1.14.0",
+      "version": "git://github.com/Rise-Vision/common-component.git#761bdde3948b81a95cb24471ca38346c2d54f8dd",
+      "from": "git://github.com/Rise-Vision/common-component.git#v1.14.1",
       "dev": true
     },
     "component-bind": {
@@ -5982,13 +5982,13 @@
           "integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
           "dev": true,
           "requires": {
-            "duplexer": "0.1.1",
-            "from": "0.1.7",
-            "map-stream": "0.0.7",
+            "duplexer": "~0.1.1",
+            "from": "~0",
+            "map-stream": "~0.0.3",
             "pause-stream": "0.0.11",
-            "split": "0.2.10",
-            "stream-combiner": "0.0.4",
-            "through": "2.3.8"
+            "split": "0.2",
+            "stream-combiner": "~0.0.3",
+            "through": "~2.3.1"
           }
         },
         "map-stream": {
@@ -6079,13 +6079,13 @@
           "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
           "dev": true,
           "requires": {
-            "duplexer": "0.1.1",
-            "from": "0.1.7",
-            "map-stream": "0.1.0",
+            "duplexer": "~0.1.1",
+            "from": "~0",
+            "map-stream": "~0.1.0",
             "pause-stream": "0.0.11",
-            "split": "0.3.3",
-            "stream-combiner": "0.0.4",
-            "through": "2.3.8"
+            "split": "0.3",
+            "stream-combiner": "~0.0.4",
+            "through": "~2.3.1"
           }
         },
         "split": {
@@ -9275,12 +9275,6 @@
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
       "dev": true,
       "optional": true
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
     },
     "nodegit-promise": {
       "version": "4.0.0",
@@ -12863,8 +12857,8 @@
       }
     },
     "widget-tester": {
-      "version": "git://github.com/Rise-Vision/widget-tester.git#da7b0cef94be5af39980c0368bf170cf6f5272d5",
-      "from": "git://github.com/Rise-Vision/widget-tester.git#1.7.3",
+      "version": "git://github.com/Rise-Vision/widget-tester.git#4cd588f42f6165d4f20220ee48008fac0f81e06b",
+      "from": "git://github.com/Rise-Vision/widget-tester.git#v1.8.1",
       "dev": true,
       "requires": {
         "async": "^0.9.0",
@@ -13044,6 +13038,12 @@
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
           "dev": true
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bower": "^1.5.3",
     "chai": "^2.1.2",
     "chai-as-promised": "^4.3.0",
-    "common-component": "git://github.com/Rise-Vision/common-component.git#v1.14.0",
+    "common-component": "git://github.com/Rise-Vision/common-component.git#v1.14.1",
     "del": "~1.1.1",
     "eslint": "^3.8.1",
     "eslint-config-idiomatic": "^2.1.0",
@@ -49,7 +49,7 @@
     "run-sequence": "^0.3.2",
     "uglify-js": "^2.6.0",
     "web-component-tester": "5.0.0",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#1.7.3"
+    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#v1.8.1"
   },
   "optionalDependencies": {
     "wct-local": "<2.0.16"

--- a/src/widget.html
+++ b/src/widget.html
@@ -55,6 +55,7 @@
   <script src="widget/player-vjs.js"></script>
   <script src="components/widget-common/dist/message.js"></script>
   <script src="widget/player-local-storage-file.js"></script>
+  <script src="widget/player-local-storage-folder.js"></script>
   <script src="widget/main.js"></script>
   <script src="widget/analytics.js"></script>
   <!-- endbuild -->

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -68,7 +68,7 @@
             RiseVision.Common.Utilities.loadScript( config.COMPONENTS_PATH + "videojs-playlist/dist/videojs-playlist.min.js" );
 
             // TODO: trigger test coverage for RLS with folder
-            useRLS = canUseRLSFolder();
+            useRLS = config.TEST_USE_RLS || canUseRLSFolder();
           } else {
             // file was selected
             mode = "file";

--- a/src/widget/player-local-storage-file.js
+++ b/src/widget/player-local-storage-file.js
@@ -27,7 +27,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
   function _startInitialProcessingTimer() {
     initialProcessingTimer = setTimeout( function() {
       // file is still processing/downloading
-      RiseVision.VideoRLS.onFileUnavailable( "File is downloading" );
+      RiseVision.VideoRLS.onFileUnavailable( "File is downloading." );
     }, INITIAL_PROCESSING_DELAY );
   }
 
@@ -40,7 +40,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       "event": "error",
       "event_details": "no connection",
       "file_url": filePath
-    }, true );
+    } );
 
     RiseVision.VideoRLS.showError( "There was a problem retrieving the file." );
   }
@@ -50,7 +50,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       "event": "error",
       "event_details": "required modules unavailable",
       "file_url": filePath
-    }, true );
+    } );
 
     RiseVision.VideoRLS.showError( "There was a problem retrieving the file." );
   }
@@ -60,7 +60,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       "event": "warning",
       "event_details": "unauthorized",
       "file_url": filePath
-    }, true );
+    } );
 
     RiseVision.VideoRLS.showError( "Rise Storage subscription is not active." );
   }
@@ -105,22 +105,22 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
     RiseVision.VideoRLS.onFileRefresh( data.fileUrl );
   }
 
-  function _handleFileNoExist() {
-    var data = {
+  function _handleFileNoExist( data ) {
+    var params = {
       "event": "warning",
       "event_details": "file does not exist",
-      "file_url": filePath
+      "file_url": data.filePath
     };
 
-    videoUtils.logEvent( data, true );
+    videoUtils.logEvent( params );
 
     RiseVision.VideoRLS.showError( "The selected video does not exist or has been moved to Trash." );
   }
 
-  function _handleFileDeleted() {
+  function _handleFileDeleted( data ) {
     videoUtils.logEvent( {
       "event": "file deleted",
-      "file_url": filePath
+      "file_url": data.filePath
     } );
   }
 
@@ -130,7 +130,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       params = {
         "event": "error",
         "event_details": msg + ( detail ? " | " + detail : "" ),
-        "file_url": filePath
+        "file_url": data.filePath
       };
 
     // prevent repetitive logging when widget is receiving messages from other potential widget instances watching same file
@@ -139,7 +139,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
     }
 
     fileErrorLogParams = _.clone( params );
-    videoUtils.logEvent( params, true );
+    videoUtils.logEvent( params );
 
     /*** Possible error messages from Local Storage ***/
     /*
@@ -186,10 +186,10 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       _handleFileProcessing();
       break;
     case "FILE-NO-EXIST":
-      _handleFileNoExist();
+      _handleFileNoExist( data );
       break;
     case "FILE-DELETED":
-      _handleFileDeleted();
+      _handleFileDeleted( data );
       break;
     case "FILE-ERROR":
       _handleFileError( data );

--- a/src/widget/player-local-storage-file.js
+++ b/src/widget/player-local-storage-file.js
@@ -97,12 +97,21 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
 
     if ( initialLoad ) {
       initialLoad = false;
-      RiseVision.VideoRLS.onFileInit( data.fileUrl );
+
+      RiseVision.VideoRLS.onFileInit( {
+        filePath: filePath,
+        url: data.fileUrl,
+        name: videoUtils.getStorageFileName( filePath )
+      } );
 
       return;
     }
 
-    RiseVision.VideoRLS.onFileRefresh( data.fileUrl );
+    RiseVision.VideoRLS.onFileRefresh( {
+      filePath: filePath,
+      url: data.fileUrl,
+      name: videoUtils.getStorageFileName( filePath )
+    } );
   }
 
   function _handleFileNoExist( data ) {

--- a/src/widget/player-local-storage-folder.js
+++ b/src/widget/player-local-storage-folder.js
@@ -1,0 +1,381 @@
+/* global localMessaging, playerLocalStorage, playerLocalStorageLicensing, config _ */
+/* eslint-disable no-console */
+
+var RiseVision = RiseVision || {};
+
+RiseVision.VideoRLS = RiseVision.VideoRLS || {};
+
+RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
+  "use strict";
+
+  var INITIAL_PROCESSING_DELAY = 15000,
+    videoUtils = RiseVision.VideoUtils,
+    messaging = new localMessaging.default(),
+    defaultFileFormat = "unknown",
+    folderPath = "",
+    licensing = null,
+    storage = null,
+    watchInitiated = false,
+    files = [],
+    filesInError = [],
+    initialProcessingTimer = null,
+    initialLoad = true;
+
+  function _getFileInError( filePath ) {
+    return _.find( filesInError, function( file ) {
+      return file.filePath === filePath;
+    } );
+  }
+
+  function _getFile( filePath ) {
+    return _.find( files, function( file ) {
+      return file.filePath === filePath;
+    } );
+  }
+
+  function _manageFileInError( data, fixed ) {
+    var filePath = data.filePath,
+      fileInError = _.find( filesInError, function( file ) {
+        return file.filePath === filePath;
+      } );
+
+    if ( !filePath ) {
+      return;
+    }
+
+    if ( fixed && fileInError ) {
+      // remove this file from files in error list
+      filesInError = _.reject( filesInError, function( file ) {
+        return file.filePath === filePath;
+      } );
+    } else if ( !fixed ) {
+      if ( !fileInError ) {
+        fileInError = {
+          filePath: filePath,
+          params: data.params
+        };
+        // add this file to list of files in error
+        filesInError.push( fileInError );
+      } else {
+        fileInError.params = _.clone( data.params );
+      }
+    }
+  }
+
+  function _manageFile( data, state ) {
+    var filePath = data.filePath,
+      fileUrl = data.fileUrl,
+      managedFile = _.find( files, function( file ) {
+        return file.filePath === filePath;
+      } );
+
+    if ( state.toUpperCase() === "AVAILABLE" ) {
+      if ( !managedFile ) {
+        managedFile = {
+          filePath: filePath,
+          url: fileUrl,
+          name: videoUtils.getStorageFileName( filePath )
+        };
+
+        // add this file to list
+        files.push( managedFile );
+      } else {
+        // file has been updated
+        managedFile.url = fileUrl
+      }
+    }
+
+    if ( state.toUpperCase() === "DELETED" ) {
+      if ( managedFile ) {
+        files = _.reject( files, function( file ) {
+          return file.filePath === filePath;
+        } );
+      }
+    }
+
+    files = _.sortBy( files, function( file ) {
+      return file.name.toLowerCase();
+    } );
+  }
+
+  function _onFileRemoved() {
+    if ( files.length < 1 ) {
+      // No files to show anymore, log and display a message
+      videoUtils.logEvent( {
+        "event": "warning",
+        "event_details": "No files to display",
+        "file_url": folderPath,
+        "file_format": "unknown"
+      } );
+
+      RiseVision.VideoRLS.showError( "Unable to display any files." );
+    } else {
+      RiseVision.VideoRLS.onFileRefresh( files );
+    }
+  }
+
+  function _clearInitialProcessingTimer() {
+    clearTimeout( initialProcessingTimer );
+    initialProcessingTimer = null;
+  }
+
+  function _startInitialProcessingTimer() {
+    initialProcessingTimer = setTimeout( function() {
+      // explicitly set to null for integration test purposes
+      initialProcessingTimer = null;
+
+      if ( files.length < 1 ) {
+        if ( filesInError.length > 0 ) {
+          // Some files during initial processing had a file error and no files became available
+          videoUtils.logEvent( {
+            "event": "warning",
+            "event_details": "No files to display (startup)",
+            "file_url": folderPath,
+            "file_format": "unknown"
+          } );
+
+          RiseVision.VideoRLS.showError( "Unable to download any files." );
+          return;
+        }
+
+        // files are still processing/downloading
+        RiseVision.VideoRLS.onFileUnavailable( "Files are downloading." );
+        return;
+      }
+
+      // settling with 1 file in case the folder only has 1 file
+      initialLoad = false;
+      RiseVision.VideoRLS.onFileInit( files );
+    }, INITIAL_PROCESSING_DELAY );
+  }
+
+  function _handleNoConnection() {
+    videoUtils.logEvent( {
+      "event": "error",
+      "event_details": "no connection",
+      "file_url": folderPath,
+      "file_format": defaultFileFormat
+    } );
+
+    RiseVision.VideoRLS.showError( "There was a problem retrieving the files." );
+  }
+
+  function _handleRequiredModulesUnavailable() {
+    videoUtils.logEvent( {
+      "event": "error",
+      "event_details": "required modules unavailable",
+      "file_url": folderPath,
+      "file_format": defaultFileFormat
+    } );
+
+    RiseVision.VideoRLS.showError( "There was a problem retrieving the files." );
+  }
+
+  function _handleUnauthorized() {
+    videoUtils.logEvent( {
+      "event": "warning",
+      "event_details": "unauthorized",
+      "file_url": folderPath,
+      "file_format": defaultFileFormat
+    } );
+
+    RiseVision.VideoRLS.showError( "Rise Storage subscription is not active." );
+  }
+
+  function _handleAuthorized() {
+    if ( !watchInitiated ) {
+      // start watching the folder
+      storage.watchFiles( folderPath, "video" );
+      watchInitiated = true;
+    }
+  }
+
+  function _handleAuthorizationError( data ) {
+    var detail = data.detail || "";
+
+    videoUtils.logEvent( {
+      "event": "error",
+      "event_details": "authorization error - " + ( ( typeof detail === "string" ) ? detail : JSON.stringify( detail ) ),
+      "file_url": folderPath,
+      "file_format": defaultFileFormat
+    } );
+  }
+
+  function _handleFileProcessing() {
+    if ( initialLoad && !initialProcessingTimer ) {
+      _startInitialProcessingTimer();
+    }
+  }
+
+  function _handleFileAvailable( data ) {
+    _manageFile( data, "available" );
+    _manageFileInError( data, true );
+
+    if ( initialLoad ) {
+      /* Try to wait for at least 2 files to load before initializing the slider. Otherwise, the
+         revolution.slide.onchange event will never fire, and this event is used to check whether or not the slider should refresh.
+         If there's only 1 file in the folder, the initialProcessingTimer will ensure the slider does get initialized anyway
+      */
+      if ( files.length > 1 ) {
+        _clearInitialProcessingTimer();
+        initialLoad = false;
+
+        RiseVision.VideoRLS.onFileInit( files );
+      }
+
+      return;
+    }
+
+    RiseVision.VideoRLS.onFileRefresh( files );
+  }
+
+  function _handleFolderNoExist() {
+    var params = {
+      "event": "error",
+      "event_details": "folder does not exist",
+      "file_url": folderPath,
+      "file_format": defaultFileFormat
+    };
+
+    videoUtils.logEvent( params );
+
+    RiseVision.VideoRLS.showError( "The selected folder does not exist or has been moved to Trash." );
+  }
+
+  function _handleFolderEmpty() {
+    var params = {
+      "event": "warning",
+      "event_details": "folder empty",
+      "file_url": folderPath,
+      "file_format": defaultFileFormat
+    };
+
+    videoUtils.logEvent( params );
+
+    RiseVision.VideoRLS.showError( "The selected folder does not contain any videos." );
+  }
+
+  function _handleFileDeleted( data ) {
+    var file = _getFile( data.filePath ),
+      params = {
+        "event": "file deleted",
+        "file_url": data.filePath,
+        "local_url": ( file && file.url ) ? file.url : ""
+      };
+
+    _manageFile( data, "deleted" );
+    _manageFileInError( data, true );
+
+    videoUtils.logEvent( params );
+
+    if ( !initialLoad && !initialProcessingTimer ) {
+      _onFileRemoved();
+    }
+  }
+
+  function _handleFileError( data ) {
+    var msg = data.msg || "",
+      detail = data.detail || "",
+      params = {
+        "event": "error",
+        "event_details": msg + ( detail ? " | " + detail : "" ),
+        "file_url": data.filePath
+      },
+      fileInError = _getFileInError( data.filePath );
+
+    // prevent repetitive logging when widget is receiving messages from other potential widget instances watching same file
+    if ( fileInError && _.isEqual( params, fileInError.params ) ) {
+      return;
+    }
+
+    _manageFileInError( {
+      filePath: data.filePath,
+      params: _.clone( params )
+    } );
+
+    /*** Possible error messages from Local Storage ***/
+    /*
+      "File's host server could not be reached"
+
+      "File I/O Error"
+
+      "Could not retrieve signed URL"
+
+      "Insufficient disk space"
+
+      "Invalid response with status code [CODE]"
+     */
+
+    videoUtils.logEvent( params );
+
+    if ( !initialLoad && !initialProcessingTimer ) {
+      if ( _getFile( data.filePath ) ) {
+        // remove this file from the file list since there was a problem with its new version being provided
+        _manageFile( { filePath: data.filePath }, "deleted" );
+        _onFileRemoved();
+      }
+    }
+  }
+
+  function _handleEvents( data ) {
+    if ( !data || !data.event || typeof data.event !== "string" ) {
+      return;
+    }
+
+    switch ( data.event.toUpperCase() ) {
+    case "NO-CONNECTION":
+      _handleNoConnection();
+      break;
+    case "REQUIRED-MODULES-UNAVAILABLE":
+      _handleRequiredModulesUnavailable();
+      break;
+    case "AUTHORIZED":
+      _handleAuthorized();
+      break;
+    case "UNAUTHORIZED":
+      _handleUnauthorized();
+      break;
+    case "AUTHORIZATION-ERROR":
+      _handleAuthorizationError;
+      break;
+    case "FILE-AVAILABLE":
+      _handleFileAvailable( data );
+      break;
+    case "FILE-PROCESSING":
+      _handleFileProcessing();
+      break;
+    case "FOLDER-NO-EXIST":
+      _handleFolderNoExist();
+      break;
+    case "FOLDER-EMPTY":
+      _handleFolderEmpty();
+      break;
+    case "FILE-DELETED":
+      _handleFileDeleted( data );
+      break;
+    case "FILE-ERROR":
+      _handleFileError( data );
+      break;
+    }
+  }
+
+  function init() {
+    var params = videoUtils.getParams(),
+      companyId = ( params.storage.companyId !== videoUtils.getCompanyId() ) ? params.storage.companyId : "";
+
+    folderPath = videoUtils.getStorageFolderPath();
+    licensing = new playerLocalStorageLicensing.default( messaging, _handleEvents, companyId, config.STORAGE_ENV );
+    storage = new playerLocalStorage.default( messaging, licensing, _handleEvents );
+  }
+
+  function retry() {
+    if ( initialLoad && !initialProcessingTimer ) {
+      _startInitialProcessingTimer();
+    }
+  }
+
+  return {
+    "init": init,
+    "retry": retry
+  };
+};

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -91,7 +91,7 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     }
 
     // Log aspect event
-    _videoUtils.logEvent( data, false );
+    _videoUtils.logEvent( data );
   }
 
   function _initPlaylist() {

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -83,8 +83,8 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
       } )
     };
 
-    if ( _videoUtils.isRLSSingleFile() ) {
-      data.file_url = _videoUtils.getStorageSingleFilePath();
+    if ( _videoUtils.getUsingRLS() ) {
+      data.file_url = ( _videoUtils.getMode() === "file" ) ? _videoUtils.getStorageSingleFilePath() : _videoUtils.getStorageFolderPath();
       data.local_url = _playerInstance.currentSrc();
     } else {
       data.file_url = _playerInstance.currentSrc();

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -83,19 +83,27 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
       } )
     };
 
-    if ( _videoUtils.getUsingRLS() ) {
-      data.file_url = ( _videoUtils.getMode() === "file" ) ? _videoUtils.getStorageSingleFilePath() : _videoUtils.getStorageFolderPath();
-      data.local_url = _playerInstance.currentSrc();
-    } else {
-      data.file_url = _playerInstance.currentSrc();
+    if ( mode === "file" ) {
+      if ( _videoUtils.getConfigurationType() !== "custom" ) {
+        data.file_url = _videoUtils.getStorageSingleFilePath();
+      } else {
+        data.file_url = ( params.url && params.url !== "" ) ? params.url : params.selector.url;
+      }
+
+    } else if ( mode === "folder" ) {
+      data.file_url = _videoUtils.getStorageFolderPath();
+      data.file_format = "WEBM|MP4|OGV|OGG";
     }
+
+    data.local_url = _playerInstance.currentSrc();
 
     // Log aspect event
     _videoUtils.logEvent( data );
   }
 
   function _initPlaylist() {
-    var playlist = [],
+    var usingRLS = _videoUtils.getUsingRLS(),
+      playlist = [],
       playlistItem,
       sources,
       source;
@@ -103,8 +111,8 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     _files.forEach( function addPlaylistItem( file ) {
       sources = [];
       source = {
-        src: file,
-        type: _utils.getVideoFileType( file )
+        src: usingRLS ? file.url : file,
+        type: _utils.getVideoFileType( ( usingRLS ? file.name : file ) )
       };
 
       sources.push( source );
@@ -147,9 +155,16 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
   }
 
   function _ready() {
+    var usingRLS = _videoUtils.getUsingRLS(),
+      fileType,
+      fileURl;
+
     if ( _files && _files.length && _files.length > 0 ) {
       if ( mode === "file" ) {
-        _playerInstance.src( { type: _utils.getVideoFileType( _files[ 0 ] ), src: _files[ 0 ] } );
+        fileType = _utils.getVideoFileType( ( usingRLS ? _files[ 0 ].name : _files[ 0 ] ) );
+        fileURl = usingRLS ? _files[ 0 ].url : _files[ 0 ];
+
+        _playerInstance.src( { type: fileType, src: fileURl } );
       } else if ( mode === "folder" ) {
         _initPlaylist();
       }
@@ -207,6 +222,10 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
   }
 
   function play() {
+    var usingRLS = _videoUtils.getUsingRLS(),
+      fileType,
+      fileURl;
+
     _isPaused = false;
 
     if ( _updateWaiting ) {
@@ -215,7 +234,10 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
       // set a new source
       if ( _files && _files.length && _files.length > 0 ) {
         if ( mode === "file" ) {
-          _playerInstance.src( { type: _utils.getVideoFileType( _files[ 0 ] ), src: _files[ 0 ] } );
+          fileType = _utils.getVideoFileType( ( usingRLS ? _files[ 0 ].name : _files[ 0 ] ) );
+          fileURl = usingRLS ? _files[ 0 ].url : _files[ 0 ];
+
+          _playerInstance.src( { type: fileType, src: fileURl } );
         } else if ( mode === "folder" ) {
           _initPlaylist();
         }

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -36,6 +36,22 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     };
   }
 
+  function _getFilePathFromSrc( url ) {
+    var filePath = "",
+      i;
+
+    if ( _videoUtils.getUsingRLS() && _files && _files.length && _files.length > 0 ) {
+      for ( i = 0; i < _files.length; i++ ) {
+        if ( _files[ i ].url === url ) {
+          filePath = _files[ i ].filePath;
+          break;
+        }
+      }
+    }
+
+    return filePath;
+  }
+
   function _onPause() {
     if ( !_isPaused ) {
       clearTimeout( _pauseTimer );
@@ -66,7 +82,7 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
 
   function _onError() {
 
-    videoRef.playerError( _playerInstance.error() );
+    videoRef.playerError( _playerInstance.error(), _playerInstance.currentSrc(), _getFilePathFromSrc( _playerInstance.currentSrc() ) );
   }
 
   function _onLoadedMetaData() {
@@ -91,8 +107,12 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
       }
 
     } else if ( mode === "folder" ) {
-      data.file_url = _videoUtils.getStorageFolderPath();
-      data.file_format = "WEBM|MP4|OGV|OGG";
+      data.file_url = _getFilePathFromSrc( _playerInstance.currentSrc() );
+
+      if ( !data.file_url ) {
+        data.file_url = _videoUtils.getStorageFolderPath();
+        data.file_format = "WEBM|MP4|OGV|OGG";
+      }
     }
 
     data.local_url = _playerInstance.currentSrc();

--- a/src/widget/storage-file.js
+++ b/src/widget/storage-file.js
@@ -52,28 +52,28 @@ RiseVision.Video.StorageFile = function( data, displayId ) {
         "event_details": "Response code: " + e.detail.code + ", message: " + e.detail.message
       };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
       RiseVision.Video.showError( "Sorry, there was a problem communicating with Rise Storage." );
     } );
 
     storage.addEventListener( "rise-storage-no-file", function( e ) {
       var params = { "event": "storage file not found", "event_details": e.detail };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
       RiseVision.Video.showError( "The selected video does not exist or has been moved to Trash." );
     } );
 
     storage.addEventListener( "rise-storage-file-throttled", function( e ) {
       var params = { "event": "storage file throttled", "file_url": e.detail };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
       RiseVision.Video.showError( "The selected video is temporarily unavailable." );
     } );
 
     storage.addEventListener( "rise-storage-subscription-expired", function() {
       var params = { "event": "storage subscription expired" };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
       RiseVision.Video.showError( "Rise Storage subscription is not active." );
     } );
 
@@ -83,7 +83,7 @@ RiseVision.Video.StorageFile = function( data, displayId ) {
         "event_details": "The request failed with status code: " + e.detail.error.currentTarget.status
       };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
     } );
 
     storage.addEventListener( "rise-storage-error", function( e ) {
@@ -92,7 +92,7 @@ RiseVision.Video.StorageFile = function( data, displayId ) {
         "event_details": "The request failed with status code: " + e.detail.error.currentTarget.status
       };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
       RiseVision.Video.showError( "Sorry, there was a problem communicating with Rise Storage.", true );
     } );
 
@@ -105,7 +105,7 @@ RiseVision.Video.StorageFile = function( data, displayId ) {
         errorMessage = "";
 
       // log the error
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
 
       riseCache.isV2Running( function showError( isV2 ) {
         if ( e.detail.error.message ) {
@@ -141,7 +141,7 @@ RiseVision.Video.StorageFile = function( data, displayId ) {
         }
       }
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
 
       if ( e.detail && e.detail.isPlayerRunning ) {
         RiseVision.Video.showError( "Waiting for Rise Cache", true );

--- a/src/widget/storage-folder.js
+++ b/src/widget/storage-folder.js
@@ -105,35 +105,35 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
         "event_details": "Response code: " + e.detail.code + ", message: " + e.detail.message
       };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
       RiseVision.Video.showError( "Sorry, there was a problem communicating with Rise Storage." );
     } );
 
     storage.addEventListener( "rise-storage-empty-folder", function() {
       var params = { "event": "storage folder empty" };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
       RiseVision.Video.showError( "The selected folder does not contain any videos." );
     } );
 
     storage.addEventListener( "rise-storage-no-folder", function( e ) {
       var params = { "event": "storage folder doesn't exist", "event_details": e.detail };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
       RiseVision.Video.showError( "The selected folder does not exist or has been moved to Trash." );
     } );
 
     storage.addEventListener( "rise-storage-folder-invalid", function() {
       var params = { "event": "storage folder format(s) invalid" };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
       RiseVision.Video.showError( "The selected folder does not contain any supported video formats." );
     } );
 
     storage.addEventListener( "rise-storage-subscription-expired", function() {
       var params = { "event": "storage subscription expired" };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
       RiseVision.Video.showError( "Rise Storage subscription is not active." );
     } );
 
@@ -143,7 +143,7 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
         "event_details": "The request failed with status code: " + e.detail.error.currentTarget.status
       };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
     } );
 
     storage.addEventListener( "rise-storage-error", function( e ) {
@@ -152,7 +152,7 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
         "event_details": "The request failed with status code: " + e.detail.error.currentTarget.status
       };
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
       RiseVision.Video.showError( "Sorry, there was a problem communicating with Rise Storage.", true );
     } );
 
@@ -164,7 +164,7 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
         statusCode = 0,
         errorMessage = "";
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
 
       riseCache.isV2Running( function showError( isV2 ) {
         if ( e.detail.error.message ) {
@@ -199,7 +199,7 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
         }
       }
 
-      videoUtils.logEvent( params, true );
+      videoUtils.logEvent( params );
 
       if ( e.detail && e.detail.isPlayerRunning ) {
         RiseVision.Video.showError( "Waiting for Rise Cache", true );

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -216,6 +216,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     var data = _.clone( params );
 
     _videoUtils.setMode( mode );
+    _videoUtils.setUsingRLS();
     _videoUtils.setCompanyId( companyId );
     _videoUtils.setDisplayId( displayId );
 

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -164,7 +164,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     }
   }
 
-  function playerError( error ) {
+  function playerError( error, localUrl, filePath ) {
     var mode = _videoUtils.getMode(),
       logParams = {},
       type = "MEDIA_ERR_UNKNOWN",
@@ -187,11 +187,17 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     logParams.event_details = type + " - " + errorMessage;
 
     if ( mode === "file" ) {
-      logParams.file_url = _videoUtils.getStorageSingleFilePath();
-      logParams.local_url = _videoUtils.getCurrentFiles()[ 0 ];
+      logParams.file_url = filePath || _videoUtils.getStorageSingleFilePath();
+      logParams.local_url = localUrl || _videoUtils.getCurrentFiles()[ 0 ];
     } else if ( mode === "folder" ) {
-      logParams.file_url = _videoUtils.getStorageFolderPath();
-      logParams.file_format = "WEBM|MP4|OGV|OGG";
+      logParams.file_url = filePath;
+
+      if ( !logParams.file_url ) {
+        logParams.file_url = _videoUtils.getStorageFolderPath();
+        logParams.file_format = "WEBM|MP4|OGV|OGG";
+      }
+
+      logParams.local_url = localUrl || "";
     }
 
     _videoUtils.logEvent( logParams );

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -14,7 +14,6 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     _player = null,
     _configurationLogged = false,
     _viewerPaused = true,
-    _configurationType = null,
     _storage = null,
     _resume = true,
     _errorFlag = false,
@@ -41,13 +40,13 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
       _message.show( "Please wait while your video is downloaded." );
 
       if ( _videoUtils.getMode() === "file" ) {
-        _configurationType = "storage file (rls)";
+        _videoUtils.setConfigurationType( "storage file (rls)" );
 
         // create and initialize the Storage file instance
         _storage = new RiseVision.VideoRLS.PlayerLocalStorageFile();
         _storage.init();
       } else if ( _videoUtils.getMode() === "folder" ) {
-        _configurationType = "storage folder (rls)";
+        _videoUtils.setConfigurationType( "storage folder (rls)" );
 
         // create and initialize the Storage folder instance
         _storage = new RiseVision.VideoRLS.PlayerLocalStorageFolder();
@@ -119,7 +118,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     var params = _videoUtils.getParams(),
       configParams = {
         "event": "configuration",
-        "event_details": _configurationType
+        "event_details": _videoUtils.getConfigurationType()
       },
       mode = _videoUtils.getMode(),
       currentFiles;

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -122,7 +122,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
       _videoUtils.logEvent( {
         event: "configuration",
         event_details: _configurationType
-      }, false );
+      } );
     }
 
     _viewerPaused = false;
@@ -174,7 +174,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     params.event = "player error";
     params.event_details = type + " - " + errorMessage;
 
-    _videoUtils.logEvent( params, true );
+    _videoUtils.logEvent( params );
     showError( errorMessage );
   }
 

--- a/src/widget/video-utils.js
+++ b/src/widget/video-utils.js
@@ -10,6 +10,7 @@ RiseVision.VideoUtils = ( function() {
     _currentFiles = [],
     _companyId = null,
     _displayId = null,
+    _usingRLS = false,
     _params = null,
     _mode = null,
     _errorTimer = null;
@@ -69,6 +70,10 @@ RiseVision.VideoUtils = ( function() {
     path += _params.storage.folder + ( _params.storage.folder.slice( -1 ) !== "/" ? "/" : "" );
 
     return "risemedialibrary-" + _params.storage.companyId + "/" + path;
+  }
+
+  function getUsingRLS() {
+    return _usingRLS;
   }
 
   function isValidDisplayId() {
@@ -132,6 +137,10 @@ RiseVision.VideoUtils = ( function() {
     _params = params;
   }
 
+  function setUsingRLS() {
+    _usingRLS = true;
+  }
+
   return {
     "clearErrorTimer": clearErrorTimer,
     "getCurrentFiles": getCurrentFiles,
@@ -143,6 +152,7 @@ RiseVision.VideoUtils = ( function() {
     "getStorageFileName": getStorageFileName,
     "getStorageSingleFilePath": getStorageSingleFilePath,
     "getStorageFolderPath": getStorageFolderPath,
+    "getUsingRLS": getUsingRLS,
     "isValidDisplayId": isValidDisplayId,
     "logEvent": logEvent,
     "playerEnded": playerEnded,
@@ -153,6 +163,7 @@ RiseVision.VideoUtils = ( function() {
     "setCompanyId": setCompanyId,
     "setMode": setMode,
     "setParams": setParams,
+    "setUsingRLS": setUsingRLS,
     "startErrorTimer": startErrorTimer,
   };
 

--- a/src/widget/video-utils.js
+++ b/src/widget/video-utils.js
@@ -8,22 +8,11 @@ RiseVision.VideoUtils = ( function() {
   var ERROR_TIMER_DELAY = 5000,
     _prefs = new gadgets.Prefs(),
     _currentFiles = [],
-    _useRLSSingleFile = false,
     _companyId = null,
     _displayId = null,
     _params = null,
     _mode = null,
     _errorTimer = null;
-
-  function _getCurrentFile() {
-    if ( _currentFiles && _currentFiles.length > 0 ) {
-      if ( _mode === "file" ) {
-        return _currentFiles[ 0 ];
-      }
-    }
-
-    return null;
-  }
 
   /*
    *  Public  Methods
@@ -32,6 +21,14 @@ RiseVision.VideoUtils = ( function() {
   function clearErrorTimer() {
     clearTimeout( _errorTimer );
     _errorTimer = null;
+  }
+
+  function getStorageFileName( filePath ) {
+    if ( !filePath || typeof filePath !== "string" ) {
+      return "";
+    }
+
+    return filePath.split( "#" ).shift().split( "?" ).shift().split( "/" ).pop();
   }
 
   function getCurrentFiles() {
@@ -66,12 +63,16 @@ RiseVision.VideoUtils = ( function() {
     return "risemedialibrary-" + _params.storage.companyId + "/" + path;
   }
 
-  function isValidDisplayId() {
-    return _displayId && _displayId !== "preview" && _displayId !== "display_id" && _displayId.indexOf( "displayId" ) === -1;
+  function getStorageFolderPath() {
+    var path = "";
+
+    path += _params.storage.folder + ( _params.storage.folder.slice( -1 ) !== "/" ? "/" : "" );
+
+    return "risemedialibrary-" + _params.storage.companyId + "/" + path;
   }
 
-  function isRLSSingleFile() {
-    return _mode === "file" && _useRLSSingleFile;
+  function isValidDisplayId() {
+    return _displayId && _displayId !== "preview" && _displayId !== "display_id" && _displayId.indexOf( "displayId" ) === -1;
   }
 
   function startErrorTimer() {
@@ -87,15 +88,6 @@ RiseVision.VideoUtils = ( function() {
   }
 
   function logEvent( data ) {
-    if ( RiseVision.VideoUtils.isRLSSingleFile() ) {
-      data.file_url = RiseVision.VideoUtils.getStorageSingleFilePath();
-      data.local_url = _getCurrentFile();
-    } else {
-      if ( !data.file_url ) {
-        data.file_url = _getCurrentFile();
-      }
-    }
-
     RiseVision.Common.LoggerUtils.logEvent( getTableName(), data );
   }
 
@@ -140,10 +132,6 @@ RiseVision.VideoUtils = ( function() {
     _params = params;
   }
 
-  function setUseRLSSingleFile() {
-    _useRLSSingleFile = true;
-  }
-
   return {
     "clearErrorTimer": clearErrorTimer,
     "getCurrentFiles": getCurrentFiles,
@@ -152,9 +140,10 @@ RiseVision.VideoUtils = ( function() {
     "getMode": getMode,
     "getParams": getParams,
     "getTableName": getTableName,
+    "getStorageFileName": getStorageFileName,
     "getStorageSingleFilePath": getStorageSingleFilePath,
+    "getStorageFolderPath": getStorageFolderPath,
     "isValidDisplayId": isValidDisplayId,
-    "isRLSSingleFile": isRLSSingleFile,
     "logEvent": logEvent,
     "playerEnded": playerEnded,
     "sendDoneToViewer": sendDoneToViewer,
@@ -164,7 +153,6 @@ RiseVision.VideoUtils = ( function() {
     "setCompanyId": setCompanyId,
     "setMode": setMode,
     "setParams": setParams,
-    "setUseRLSSingleFile": setUseRLSSingleFile,
     "startErrorTimer": startErrorTimer,
   };
 

--- a/src/widget/video-utils.js
+++ b/src/widget/video-utils.js
@@ -10,6 +10,7 @@ RiseVision.VideoUtils = ( function() {
     _currentFiles = [],
     _companyId = null,
     _displayId = null,
+    _configurationType = null,
     _usingRLS = false,
     _params = null,
     _mode = null,
@@ -38,6 +39,10 @@ RiseVision.VideoUtils = ( function() {
 
   function getCompanyId() {
     return _companyId;
+  }
+
+  function getConfigurationType() {
+    return _configurationType;
   }
 
   function getDisplayId() {
@@ -114,15 +119,19 @@ RiseVision.VideoUtils = ( function() {
       return;
     }
 
-    if ( typeof urls === "string" ) {
-      _currentFiles[ 0 ] = urls;
-    } else if ( Array.isArray( urls ) && urls.length > 0 ) {
+    if ( Array.isArray( urls ) && urls.length > 0 ) {
       _currentFiles = urls;
+    } else {
+      _currentFiles[ 0 ] = urls;
     }
   }
 
   function setCompanyId( companyId ) {
     _companyId = companyId;
+  }
+
+  function setConfigurationType( type ) {
+    _configurationType = type;
   }
 
   function setDisplayId( displayId ) {
@@ -145,6 +154,7 @@ RiseVision.VideoUtils = ( function() {
     "clearErrorTimer": clearErrorTimer,
     "getCurrentFiles": getCurrentFiles,
     "getCompanyId": getCompanyId,
+    "getConfigurationType": getConfigurationType,
     "getDisplayId": getDisplayId,
     "getMode": getMode,
     "getParams": getParams,
@@ -158,6 +168,7 @@ RiseVision.VideoUtils = ( function() {
     "playerEnded": playerEnded,
     "sendDoneToViewer": sendDoneToViewer,
     "sendReadyToViewer": sendReadyToViewer,
+    "setConfigurationType": setConfigurationType,
     "setCurrentFiles": setCurrentFiles,
     "setDisplayId": setDisplayId,
     "setCompanyId": setCompanyId,

--- a/src/widget/video.js
+++ b/src/widget/video.js
@@ -223,7 +223,7 @@ RiseVision.Video = ( function( window, gadgets ) {
   }
 
   // An error occurred with Player.
-  function playerError( error ) {
+  function playerError( error, localUrl ) {
     var params = _videoUtils.getParams(),
       mode = _videoUtils.getMode(),
       logParams = {},
@@ -253,11 +253,12 @@ RiseVision.Video = ( function( window, gadgets ) {
         logParams.file_url = ( params.url && params.url !== "" ) ? params.url : params.selector.url;
       }
 
-      logParams.local_url = _videoUtils.getCurrentFiles()[ 0 ];
+      logParams.local_url = localUrl || _videoUtils.getCurrentFiles()[ 0 ];
 
     } else if ( mode === "folder" ) {
       logParams.file_url = _videoUtils.getStorageFolderPath();
       logParams.file_format = "WEBM|MP4|OGV|OGG";
+      logParams.local_url = localUrl || "";
     }
 
     _playerErrorFlag = true;

--- a/src/widget/video.js
+++ b/src/widget/video.js
@@ -8,7 +8,6 @@ RiseVision.Video = ( function( window, gadgets ) {
   "use strict";
 
   var _configurationLogged = false,
-    _configDetails = null,
     _videoUtils = RiseVision.VideoUtils,
     _prefs = new gadgets.Prefs(),
     _storage = null,
@@ -54,19 +53,19 @@ RiseVision.Video = ( function( window, gadgets ) {
         isStorageFile = ( Object.keys( params.storage ).length !== 0 );
 
         if ( !isStorageFile ) {
-          _configDetails = "custom";
+          _videoUtils.setConfigurationType( "custom" );
 
           _nonStorage = new RiseVision.Video.NonStorage( params );
           _nonStorage.init();
         } else {
-          _configDetails = "storage file";
+          _videoUtils.setConfigurationType( "storage file" );
 
           // create and initialize the Storage file instance
           _storage = new RiseVision.Video.StorageFile( params, _videoUtils.getDisplayId() );
           _storage.init();
         }
       } else if ( _videoUtils.getMode() === "folder" ) {
-        _configDetails = "storage folder";
+        _videoUtils.setConfigurationType( "storage folder" );
 
         // create and initialize the Storage folder instance
         _storage = new RiseVision.Video.StorageFolder( params, _videoUtils.getDisplayId() );
@@ -142,14 +141,14 @@ RiseVision.Video = ( function( window, gadgets ) {
     var params = _videoUtils.getParams(),
       configParams = {
         "event": "configuration",
-        "event_details": _configDetails
+        "event_details": _videoUtils.getConfigurationType()
       },
       mode = _videoUtils.getMode(),
       currentFiles;
 
     if ( !_configurationLogged ) {
       if ( mode === "file" ) {
-        if ( _configDetails !== "custom" ) {
+        if ( _videoUtils.getConfigurationType() !== "custom" ) {
           configParams.file_url = _videoUtils.getStorageSingleFilePath();
         } else {
           configParams.file_url = ( params.url && params.url !== "" ) ? params.url : params.selector.url;
@@ -248,7 +247,7 @@ RiseVision.Video = ( function( window, gadgets ) {
     logParams.event_details = type + " - " + errorMessage;
 
     if ( mode === "file" ) {
-      if ( _configDetails !== "custom" ) {
+      if ( _videoUtils.getConfigurationType() !== "custom" ) {
         logParams.file_url = _videoUtils.getStorageSingleFilePath();
       } else {
         logParams.file_url = ( params.url && params.url !== "" ) ? params.url : params.selector.url;

--- a/src/widget/video.js
+++ b/src/widget/video.js
@@ -149,7 +149,7 @@ RiseVision.Video = ( function( window, gadgets ) {
       _videoUtils.logEvent( {
         event: "configuration",
         event_details: _configDetails
-      }, false );
+      } );
     }
 
     _viewerPaused = false;
@@ -234,7 +234,7 @@ RiseVision.Video = ( function( window, gadgets ) {
     params.event_details = type + " - " + errorMessage;
     _playerErrorFlag = true;
 
-    _videoUtils.logEvent( params, true );
+    _videoUtils.logEvent( params );
     showError( errorMessage );
   }
 

--- a/test/index.html
+++ b/test/index.html
@@ -32,8 +32,11 @@
     "integration/storage-v2/messaging-folder.html",
     "integration/storage-v2/version.html",
     "integration/player-local-storage/file.html",
+    "integration/player-local-storage/folder.html",
     "integration/player-local-storage/logging-file.html",
-    "integration/player-local-storage/messaging-file.html"
+    "integration/player-local-storage/logging-folder.html",
+    "integration/player-local-storage/messaging-file.html",
+    "integration/player-local-storage/messaging-folder.html"
   ]);
 </script>
 </body>

--- a/test/integration/js/file.js
+++ b/test/integration/js/file.js
@@ -163,7 +163,7 @@ suite( "Storage Errors", function() {
     } ) );
 
     assert( onLogEventStub.calledOnce, "logEvent() called once" );
-    assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
+    assert( onLogEventStub.calledWith( params ), "logEvent() called with correct params" );
     assert( onShowErrorStub.calledOnce, "showError() called once" );
     assert( onShowErrorStub.calledWith( "The selected video does not exist or has been moved to Trash." ),
       "showError() called with correct message" );
@@ -179,7 +179,7 @@ suite( "Storage Errors", function() {
     } ) );
 
     assert( onLogEventStub.calledOnce, "logEvent() called once" );
-    assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
+    assert( onLogEventStub.calledWith( params ), "logEvent() called with correct params" );
     assert( onShowErrorStub.calledOnce, "showError() called once" );
     assert( onShowErrorStub.calledWith( "The selected video is temporarily unavailable." ),
       "showError() called with correct message" );
@@ -200,7 +200,7 @@ suite( "Storage Errors", function() {
     } ) );
 
     assert( onLogEventStub.calledOnce, "logEvent() called once" );
-    assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
+    assert( onLogEventStub.calledWith( params ), "logEvent() called with correct params" );
     assert( onShowErrorStub.calledOnce, "showError() called once" );
     assert( onShowErrorStub.calledWith( "Sorry, there was a problem communicating with Rise Storage." ),
       "showError() called with correct message" );
@@ -223,7 +223,7 @@ suite( "Storage Errors", function() {
     } ) );
 
     assert( onLogEventStub.calledOnce, "logEvent() called once" );
-    assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
+    assert( onLogEventStub.calledWith( params ), "logEvent() called with correct params" );
     assert( onShowErrorStub.calledOnce, "showError() called once" );
     assert( onShowErrorStub.calledWith( "Sorry, there was a problem communicating with Rise Storage." ),
       "showError() called with correct message" );
@@ -263,7 +263,7 @@ suite( "Storage Errors", function() {
     }
 
     assert( onLogEventStub.calledOnce, "logEvent() called once" );
-    assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
+    assert( onLogEventStub.calledWith( params ), "logEvent() called with correct params" );
     assert( onShowErrorStub.calledOnce, "showError() called once" );
   } );
 
@@ -302,7 +302,7 @@ suite( "Storage Errors", function() {
     }
 
     assert( onLogEventStub.calledOnce, "logEvent() called once" );
-    assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
+    assert( onLogEventStub.calledWith( params ), "logEvent() called with correct params" );
 
   } );
 

--- a/test/integration/js/folder.js
+++ b/test/integration/js/folder.js
@@ -290,7 +290,7 @@ suite( "storage errors", function() {
     }
 
     assert( onLogEventStub.calledOnce, "logEvent() called once" );
-    assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
+    assert( onLogEventStub.calledWith( params ), "logEvent() called with correct params" );
 
   } );
 } );

--- a/test/integration/js/logging-file.js
+++ b/test/integration/js/logging-file.js
@@ -9,7 +9,8 @@ var spy,
   table = "video_v2_events",
   params = {
     "event": "storage file not found",
-    "file_url": null,
+    "file_url": "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+    "file_format": "webm",
     /* eslint-disable quotes */
     "company_id": '"companyId"',
     "display_id": '"displayId"',
@@ -49,6 +50,7 @@ suite( "configuration", function() {
       "event": "configuration",
       "event_details": "storage file",
       "file_url": params.file_url,
+      "file_format": params.file_format,
       "company_id": params.company_id,
       "display_id": params.display_id,
       "version": params.version
@@ -67,6 +69,8 @@ suite( "storage file not found", function() {
     } ) );
 
     params.event_details = "/Fish_Tank_Project.webm";
+    delete params.file_url;
+    delete params.file_format;
 
     assert( spy.calledOnce );
     assert( spy.calledWith( table, params ) );
@@ -177,7 +181,7 @@ suite( "storage subscription expired", function() {
     storage.dispatchEvent( new CustomEvent( "rise-storage-subscription-expired" ) );
 
     params.event = "storage subscription expired";
-    params.file_url = null;
+    delete params.file_url;
     delete params.file_format;
 
     assert( spy.calledOnce );

--- a/test/integration/js/logging-folder.js
+++ b/test/integration/js/logging-folder.js
@@ -11,7 +11,8 @@ var playStub,
   table = "video_v2_events",
   params = {
     "event": "storage folder empty",
-    "file_url": null,
+    "file_url": "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/",
+    "file_format": "WEBM|MP4|OGV|OGG",
     /* eslint-disable quotes */
     "company_id": '"companyId"',
     "display_id": '"displayId"',
@@ -57,6 +58,7 @@ suite( "configuration", function() {
       "event": "configuration",
       "event_details": "storage folder",
       "file_url": params.file_url,
+      "file_format": params.file_format,
       "company_id": params.company_id,
       "display_id": params.display_id,
       "version": params.version
@@ -73,6 +75,9 @@ suite( "storage folder empty", function() {
       "detail": null,
       "bubbles": true
     } ) );
+
+    delete params.file_url;
+    delete params.file_format;
 
     assert( spy.calledOnce );
     assert( spy.calledWith( table, params ) );

--- a/test/integration/js/player-local-storage-file.js
+++ b/test/integration/js/player-local-storage-file.js
@@ -55,7 +55,11 @@ suite( "file added", function() {
 
   test( "should be able to set single video with correct url", function() {
     assert( onFileInitSpy.calledOnce, "onFileInit() called once" );
-    assert( onFileInitSpy.calledWith( "file:///path/to/file/abc123" ), "onFileInit() called with correct url" );
+    assert( onFileInitSpy.calledWith( {
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+      name: "a_food_show.webm",
+      url: "file:///path/to/file/abc123"
+    } ), "onFileInit() called with correct data" );
   } );
 } );
 
@@ -92,6 +96,10 @@ suite( "file changed", function() {
     } );
 
     assert( refreshSpy.calledOnce );
-    assert( refreshSpy.calledWith( "file:///path/to/file/def456" ), "onFileRefresh() called with correct url" );
+    assert( refreshSpy.calledWith( {
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+      name: "a_food_show.webm",
+      url: "file:///path/to/file/def456"
+    } ), "onFileRefresh() called with correct data" );
   } );
 } );

--- a/test/integration/js/player-local-storage-folder-one-file.js
+++ b/test/integration/js/player-local-storage-folder-one-file.js
@@ -1,0 +1,121 @@
+/* global suiteSetup, suite, test, assert, setup, teardown, suiteTeardown,
+ RiseVision, sinon */
+
+/* eslint-disable func-names */
+
+var messageHandlers;
+
+suite( "initialized with 1 file", function() {
+  var onFileInitSpy,
+    clock;
+
+  suiteSetup( function() {
+    onFileInitSpy = sinon.stub( RiseVision.VideoRLS, "onFileInit" );
+
+    // mock receiving client-list message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "client-list",
+        clients: [ "local-storage", "licensing" ]
+      } );
+    } );
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoRLS.onFileInit.restore();
+  } );
+
+  setup( function() {
+    clock = sinon.useFakeTimers();
+  } );
+
+  teardown( function() {
+    clock.restore();
+  } );
+
+  test( "should be able to configure player with 1 file in folder", function() {
+    // mock receiving storage-licensing message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "storage-licensing-update",
+        isAuthorized: true,
+        userFriendlyStatus: "authorized"
+      } );
+    } );
+
+    // mock receiving file-update to notify files are downloading
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+        status: "STALE"
+      } );
+    } );
+
+    clock.tick( 7000 );
+
+    assert( !onFileInitSpy.called, "onFileInit() is not called, processing timer running" );
+
+    // mock receiving file-update to notify files are available
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+        status: "CURRENT",
+        ospath: "path/to/file/abc123",
+        osurl: "file:///path/to/file/abc123"
+      } );
+    } );
+
+    clock.tick( 7000 );
+
+    assert( !onFileInitSpy.called, "onFileInit() is not called, processing timer still running to try and get at least 2 files" );
+
+    // 15 seconds is up
+    clock.tick( 1000 );
+
+    assert( onFileInitSpy.calledOnce, "onFileInit() called once" );
+    assert.equal( onFileInitSpy.args[ 0 ][ 0 ].length, 1, "intialized with 1 file" );
+    assert.equal( onFileInitSpy.args[ 0 ][ 0 ][ 0 ].url, "file:///path/to/file/abc123", "url is correct" );
+  } );
+} );
+
+suite( "file updated", function() {
+  var onFileRefreshStub;
+
+  suiteSetup( function() {
+
+    onFileRefreshStub = sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+
+    // mock receiving file-update to notify a new file is available in this watched folder
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+        status: "STALE"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+        status: "CURRENT",
+        ospath: "path/to/file/cba321",
+        osurl: "file:///path/to/file/cba321"
+      } );
+    } );
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoRLS.onFileRefresh.restore();
+  } );
+
+  test( "should be able to configure player with an updated version of the one file in folder", function() {
+    assert( onFileRefreshStub.calledOnce, "onFileRefresh() called once" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ].length, 1, "refreshed with 1 file" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 0 ].url, "file:///path/to/file/cba321", "updated file url is correct" );
+  } );
+} );

--- a/test/integration/js/player-local-storage-folder.js
+++ b/test/integration/js/player-local-storage-folder.js
@@ -1,0 +1,240 @@
+/* global suiteSetup, suite, test, assert, suiteTeardown,
+ RiseVision, sinon */
+
+/* eslint-disable func-names */
+
+var messageHandlers;
+
+suite( "files initialized", function() {
+  var onFileInitSpy;
+
+  suiteSetup( function() {
+    onFileInitSpy = sinon.stub( RiseVision.VideoRLS, "onFileInit" );
+
+    // mock receiving client-list message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "client-list",
+        clients: [ "local-storage", "licensing" ]
+      } );
+    } );
+
+    // mock receiving storage-licensing message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "storage-licensing-update",
+        isAuthorized: true,
+        userFriendlyStatus: "authorized"
+      } );
+    } );
+
+    // mock receiving file-update to notify files are downloading
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-c.webm",
+        status: "STALE"
+      } );
+
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+        status: "STALE"
+      } );
+    } );
+
+
+    // mock receiving file-update to notify files are available
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-c.webm",
+        status: "CURRENT",
+        ospath: "path/to/file/def456",
+        osurl: "file:///path/to/file/def456"
+      } );
+
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+        status: "CURRENT",
+        ospath: "path/to/file/abc123",
+        osurl: "file:///path/to/file/abc123"
+      } );
+    } );
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoRLS.onFileInit.restore();
+  } );
+
+  test( "should be able to configure player with correct urls", function() {
+    assert( onFileInitSpy.calledOnce, "onFileInit() called once" );
+    assert.equal( onFileInitSpy.args[ 0 ][ 0 ].length, 2, "intialized with 2 files" );
+    assert.equal( onFileInitSpy.args[ 0 ][ 0 ][ 0 ].filePath, "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm", "file are sorted alphabetically ascending" );
+    assert.equal( onFileInitSpy.args[ 0 ][ 0 ][ 0 ].url, "file:///path/to/file/abc123", "file 1 url is correct" );
+    assert.equal( onFileInitSpy.args[ 0 ][ 0 ][ 1 ].url, "file:///path/to/file/def456", "file 2 url is correct" );
+  } );
+} );
+
+suite( "file added", function() {
+  var onFileRefreshStub;
+
+  suiteSetup( function() {
+
+    onFileRefreshStub = sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+
+    // mock receiving file-update to notify a new file is available in this watched folder
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+        status: "STALE"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+        status: "CURRENT",
+        ospath: "path/to/file/ghi789",
+        osurl: "file:///path/to/file/ghi789"
+      } );
+    } );
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoRLS.onFileRefresh.restore();
+  } );
+
+  test( "should be able to configure player with an additional video", function() {
+    assert( onFileRefreshStub.calledOnce, "onFileRefresh() called once" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ].length, 3, "refreshed with 3 files" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 1 ].filePath, "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm", "file are sorted alphabetically ascending" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 1 ].url, "file:///path/to/file/ghi789", "file 3 url is correct" );
+  } );
+} );
+
+suite( "file updated", function() {
+  var onFileRefreshStub;
+
+  suiteSetup( function() {
+
+    onFileRefreshStub = sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+
+    // mock receiving file-update to notify a new file is available in this watched folder
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+        status: "STALE"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+        status: "CURRENT",
+        ospath: "path/to/file/cba321",
+        osurl: "file:///path/to/file/cba321"
+      } );
+    } );
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoRLS.onFileRefresh.restore();
+  } );
+
+  test( "should be able to configure player with an updated video", function() {
+    assert( onFileRefreshStub.calledOnce, "onFileRefresh() called once" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ].length, 3, "refreshed with 3 files" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 0 ].filePath, "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm", "files remain sorted alphabetically ascending" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 0 ].url, "file:///path/to/file/cba321", "updated file url is correct" );
+  } );
+} );
+
+suite( "file deleted", function() {
+  var onFileRefreshStub;
+
+  suiteSetup( function() {
+
+    onFileRefreshStub = sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+
+    // mock receiving file-update to notify a new file is available in this watched folder
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+        status: "DELETED"
+      } );
+    } );
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoRLS.onFileRefresh.restore();
+  } );
+
+  test( "should be able to configure player after a video was deleted", function() {
+    assert( onFileRefreshStub.calledOnce, "onFileRefresh() called once" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ].length, 2, "refreshed with 2 files" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 1 ].filePath, "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-c.webm", "files remain sorted alphabetically ascending" );
+  } );
+} );
+
+suite( "file error from update", function() {
+  var onFileRefreshStub;
+
+  suiteSetup( function() {
+
+    onFileRefreshStub = sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+
+    // mock adding this file
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+        status: "STALE"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+        status: "CURRENT",
+        ospath: "path/to/file/ghi789",
+        osurl: "file:///path/to/file/ghi789"
+      } );
+    } );
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoRLS.onFileRefresh.restore();
+  } );
+
+  test( "should be able to configure player after file error received for one of the videos in list", function() {
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ].length, 3, "refreshed with 3 files" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 1 ].url, "file:///path/to/file/ghi789", "file 3 url is correct" );
+
+    // mock FILE-ERROR for this image
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-ERROR",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+        msg: "Insufficient disk space"
+      } );
+    } );
+
+    // file should be removed from list provided to onFileRefresh()
+    assert( onFileRefreshStub.calledTwice, "onFileRefresh() called twice" );
+    assert.equal( onFileRefreshStub.args[ 1 ][ 0 ].length, 2, "refreshed with 2 files" );
+    assert.equal( onFileRefreshStub.args[ 1 ][ 0 ][ 1 ].url, "file:///path/to/file/def456", "file 2 url is correct" );
+  } );
+} );

--- a/test/integration/js/player-local-storage-logging-file.js
+++ b/test/integration/js/player-local-storage-logging-file.js
@@ -9,7 +9,6 @@ var table = "video_v2_events",
     "event_details": "",
     "file_url": "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
     "file_format": "webm",
-    "local_url": null,
     "company_id": "\"companyId\"",
     "display_id": "\"displayId\"",
     "version": "1.1.0"
@@ -45,7 +44,6 @@ suite( "configuration", function() {
       "event_details": "storage file (rls)",
       "file_url": params.file_url,
       "file_format": params.file_format,
-      "local_url": params.local_url,
       "company_id": params.company_id,
       "display_id": params.display_id,
       "version": params.version
@@ -199,7 +197,6 @@ suite( "errors", function() {
 
     params.event = "file deleted";
     delete params.event_details;
-    delete params.error_details;
 
     assert( logSpy.calledOnce );
     assert( logSpy.calledWith( table, params ) );

--- a/test/integration/js/player-local-storage-logging-folder.js
+++ b/test/integration/js/player-local-storage-logging-folder.js
@@ -1,0 +1,354 @@
+/* global suiteSetup, suite, setup, teardown, test, assert,
+ RiseVision, sinon */
+
+/* eslint-disable func-names */
+
+var table = "video_v2_events",
+  params = {
+    "event": "error",
+    "event_details": "",
+    "file_url": "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/",
+    "file_format": "unknown",
+    "company_id": "\"companyId\"",
+    "display_id": "\"displayId\"",
+    "version": "1.1.0"
+  },
+  ready = false,
+  messageHandlers,
+  logSpy,
+  check = function( done ) {
+    if ( ready ) {
+      sinon.stub( RiseVision.VideoRLS, "play" );
+      done();
+    } else {
+      setTimeout( function() {
+        check( done )
+      }, 1000 );
+    }
+  };
+
+suiteSetup( function( done ) {
+  check( done );
+} );
+
+teardown( function() {
+  logSpy.restore();
+} );
+
+suite( "configuration", function() {
+
+  test( "should log the configuration event", function() {
+
+    assert( logSpy.calledWith( table, {
+      "event": "configuration",
+      "event_details": "storage folder (rls)",
+      "file_url": params.file_url,
+      "file_format": "WEBM|MP4|OGV|OGG",
+      "company_id": params.company_id,
+      "display_id": params.display_id,
+      "version": params.version
+    } ) );
+
+  } );
+} );
+
+suite( "errors", function() {
+  var clock;
+
+  setup( function() {
+    clock = sinon.useFakeTimers();
+  } );
+
+  teardown( function() {
+    clock.restore();
+  } );
+
+  test( "required modules unavailable", function() {
+    var i;
+
+    function receiveClientList() {
+      // mock receiving client-list message
+      messageHandlers.forEach( function( handler ) {
+        handler( {
+          topic: "client-list",
+          clients: [ "local-messaging" ]
+        } );
+      } );
+    }
+
+    logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
+
+    // mock 30 more client-list messages sent/received
+    for ( i = 30; i >= 0; i-- ) {
+      receiveClientList();
+      clock.tick( 1000 );
+    }
+
+    params.event_details = "required modules unavailable";
+
+    assert( logSpy.calledOnce );
+    assert( logSpy.calledWith( table, params ) );
+  } );
+
+  test( "unauthorized", function() {
+    logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
+
+    // mock receiving client-list message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "client-list",
+        clients: [ "local-storage", "licensing" ]
+      } );
+    } );
+
+    // mock receiving storage-licensing message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "storage-licensing-update",
+        isAuthorized: false,
+        userFriendlyStatus: "unauthorized"
+      } );
+    } );
+
+    params.event = "warning";
+    params.event_details = "unauthorized";
+
+    assert( logSpy.calledOnce );
+    assert( logSpy.calledWith( table, params ) );
+
+  } );
+
+  test( "folder does not exist", function() {
+    logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
+
+    // mock receiving storage-licensing message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "storage-licensing-update",
+        isAuthorized: true,
+        userFriendlyStatus: "authorized"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-update",
+        filePath: params.file_url,
+        status: "NOEXIST"
+      } );
+    } );
+
+    params.event = "error";
+    params.event_details = "folder does not exist";
+
+    assert( logSpy.calledOnce );
+    assert( logSpy.calledWith( table, params ) );
+
+  } );
+
+  test( "file error", function() {
+    var logParams;
+
+    logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-error",
+        filePath: params.file_url + "test-file-in-error.webm",
+        msg: "Could not retrieve signed URL",
+        detail: "error details"
+      } );
+    } );
+
+    logParams = JSON.parse( JSON.stringify( params ) );
+    logParams.file_url = params.file_url + "test-file-in-error.webm";
+    logParams.file_format = "webm";
+    logParams.event_details = "Could not retrieve signed URL | error details";
+
+    assert( logSpy.calledOnce );
+    assert( logSpy.calledWith( table, logParams ) );
+
+    // file is getting processed, starts the initial processing timer
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: params.file_url + "test-file-in-error-2.webm",
+        status: "STALE"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-error",
+        filePath: params.file_url + "test-file-in-error-2.webm",
+        msg: "Could not retrieve signed URL",
+        detail: "error details"
+      } );
+    } );
+
+    logParams.file_url = params.file_url + "test-file-in-error-2.webm";
+
+    assert( logSpy.calledTwice );
+    assert( logSpy.calledWith( table, logParams ) );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-error",
+        filePath: params.file_url + "test-file-in-error.webm",
+        msg: "Could not retrieve signed URL",
+        detail: "error details"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-error",
+        filePath: params.file_url + "test-file-in-error-2.webm",
+        msg: "Could not retrieve signed URL",
+        detail: "error details"
+      } );
+    } );
+
+    // should still have only logged once per file in error
+    assert.equal( logSpy.callCount, 2 );
+
+    // initial processing timer expires
+    clock.tick( 15000 );
+
+    // should log a warning about no files to display
+    logParams.event = "warning";
+    logParams.event_details = "No files to display (startup)";
+    logParams.file_url = params.file_url;
+    logParams.file_format = "unknown";
+    delete logParams.error_details;
+
+    assert.equal( logSpy.callCount, 3 );
+    assert( logSpy.calledWith( table, logParams ) );
+
+    // force file corrected
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: params.file_url + "test-file-in-error-2.webm",
+        status: "STALE"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: params.file_url + "test-file-in-error-2.webm",
+        status: "CURRENT",
+        ospath: "path/to/file/abc123",
+        osurl: "file:///path/to/file/abc123"
+      } );
+    } );
+
+    // force initialLoad to complete and be set to false
+    clock.tick( 15000 );
+
+    // file has an error again on a later update, should be able to log error again since it was previously removed from filesInError list
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-error",
+        filePath: params.file_url + "test-file-in-error-2.webm",
+        msg: "Could not retrieve signed URL",
+        detail: "error details"
+      } );
+    } );
+
+    logParams.event = params.event;
+    logParams.file_url = params.file_url + "test-file-in-error-2.webm";
+    logParams.file_format = "webm";
+    logParams.event_details = "Could not retrieve signed URL | error details";
+
+    assert.equal( logSpy.callCount, 5 );
+    assert( logSpy.calledWith( table, logParams ) );
+
+  } );
+
+} );
+
+suite( "folder file deleted", function() {
+  test( "should log when a file in folder is deleted", function() {
+    var logParams = JSON.parse( JSON.stringify( params ) );
+
+    logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
+
+    // file is added
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: params.file_url + "test-file-delete.webm",
+        status: "STALE"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: params.file_url + "test-file-delete.webm",
+        status: "CURRENT",
+        ospath: "path/to/file/abc123",
+        osurl: "file:///path/to/file/abc123"
+      } );
+    } );
+
+    assert.equal( logSpy.callCount, 0 );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: params.file_url + "test-file-delete.webm",
+        status: "DELETED"
+      } );
+    } );
+
+    logParams.event = "file deleted";
+    logParams.file_url = params.file_url + "test-file-delete.webm";
+    logParams.file_format = "webm";
+    logParams.local_url = "file:///path/to/file/abc123";
+    delete logParams.event_details;
+
+    assert( logSpy.calledTwice );
+    assert( logSpy.calledWith( table, logParams ) );
+    // no files left to display, should log a warning
+    assert( logSpy.calledWith( table, {
+      event: "warning",
+      event_details: "No files to display",
+      file_url: params.file_url,
+      file_format: "unknown",
+      company_id: params.company_id,
+      display_id: params.display_id,
+      version: params.version
+    } ) );
+
+  } );
+} );
+
+suite( "folder is empty", function() {
+
+  test( "should log a warning when a folder is empty", function() {
+    var logParams = JSON.parse( JSON.stringify( params ) );
+
+    logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-update",
+        filePath: params.file_url,
+        status: "EMPTYFOLDER"
+      } );
+    } );
+
+    logParams.event = "warning";
+    logParams.event_details = "folder empty";
+    logParams.file_url = params.file_url;
+    logParams.file_format = "unknown";
+
+    assert( logSpy.calledOnce );
+    assert( logSpy.calledWith( table, logParams ) );
+
+  } );
+
+} );

--- a/test/integration/js/player-local-storage-messaging-folder.js
+++ b/test/integration/js/player-local-storage-messaging-folder.js
@@ -1,0 +1,225 @@
+/* global suiteSetup, suite, setup, teardown, test, assert,
+ RiseVision, sinon */
+
+/* eslint-disable func-names */
+
+var ready = false,
+  folderPath = "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/",
+  messageHandlers,
+  clock,
+  check = function( done ) {
+    if ( ready ) {
+      done();
+    } else {
+      setTimeout( function() {
+        check( done )
+      }, 1000 );
+    }
+  };
+
+suiteSetup( function( done ) {
+  check( done );
+} );
+
+suite( "waiting", function() {
+  test( "should show waiting message", function() {
+    assert.equal( document.querySelector( ".message" ).innerHTML, "Please wait while your video is downloaded.", "message is correct" );
+  } );
+} );
+
+suite( "errors", function() {
+  var clock;
+
+  setup( function() {
+    clock = sinon.useFakeTimers();
+  } );
+
+  teardown( function() {
+    clock.restore();
+  } );
+
+  test( "required modules unavailable", function() {
+    var i;
+
+    function receiveClientList() {
+      // mock receiving client-list message
+      messageHandlers.forEach( function( handler ) {
+        handler( {
+          topic: "client-list",
+          clients: [ "local-messaging" ]
+        } );
+      } );
+    }
+
+    // mock 30 more client-list messages sent/received
+    for ( i = 30; i >= 0; i-- ) {
+      receiveClientList();
+      clock.tick( 1000 );
+    }
+
+    assert.equal( document.querySelector( ".message" ).innerHTML, "There was a problem retrieving the files." );
+  } );
+
+  test( "unauthorized", function() {
+    // mock receiving client-list message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "client-list",
+        clients: [ "local-storage", "licensing" ]
+      } );
+    } );
+
+    // mock receiving storage-licensing message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "storage-licensing-update",
+        isAuthorized: false,
+        userFriendlyStatus: "unauthorized"
+      } );
+    } );
+
+    assert.equal( document.querySelector( ".message" ).innerHTML, "Rise Storage subscription is not active." );
+  } );
+
+  test( "folder does not exist", function() {
+    // mock receiving storage-licensing message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "storage-licensing-update",
+        isAuthorized: true,
+        userFriendlyStatus: "authorized"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-update",
+        filePath: folderPath,
+        status: "NOEXIST"
+      } );
+    } );
+
+    assert.equal( document.querySelector( ".message" ).innerHTML, "The selected folder does not exist or has been moved to Trash." );
+  } );
+
+  test( "folder is empty", function() {
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-update",
+        filePath: folderPath,
+        status: "EMPTYFOLDER"
+      } );
+    } );
+
+    assert.equal( document.querySelector( ".message" ).innerHTML, "The selected folder does not contain any videos." );
+
+  } );
+
+} );
+
+suite( "files downloading", function() {
+
+  setup( function() {
+    clock = sinon.useFakeTimers();
+  } );
+
+  teardown( function() {
+    clock.restore();
+  } );
+
+  test( "should show message after 15 seconds of processing", function() {
+
+    // files are getting processed, starts the initial processing timer
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: folderPath + "test-file.webm",
+        status: "STALE"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: folderPath + "test-file-2.webm",
+        status: "STALE"
+      } );
+    } );
+
+    // expire initial processing timer
+    clock.tick( 15000 );
+
+    assert.equal( document.querySelector( ".message" ).innerHTML, "Files are downloading." );
+
+  } );
+
+} );
+
+suite( "file error", function() {
+
+  setup( function() {
+    sinon.stub( RiseVision.VideoRLS, "onFileInit" );
+    sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+    clock = sinon.useFakeTimers();
+  } );
+
+  teardown( function() {
+    RiseVision.VideoRLS.onFileInit.restore();
+    RiseVision.VideoRLS.onFileRefresh.restore();
+    clock.restore();
+  } );
+
+  test( "should display message when all files in error", function() {
+    var spy = sinon.spy( RiseVision.VideoRLS, "play" );
+
+    // successfully initialize widget and clear messages
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: folderPath + "test-file.webm",
+        status: "CURRENT",
+        ospath: "path/to/file/abc123",
+        osurl: "file:///path/to/file/abc123"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: folderPath + "test-file-2.webm",
+        status: "CURRENT",
+        ospath: "path/to/file/def456",
+        osurl: "file:///path/to/file/def456"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-error",
+        filePath: folderPath + "test-file.webm",
+        msg: "File's host server could not be reached",
+        detail: "error details"
+      } );
+    } );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-error",
+        filePath: folderPath + "test-file-2.webm",
+        msg: "File's host server could not be reached",
+        detail: "error details"
+      } );
+    } );
+
+    assert.equal( document.querySelector( ".message" ).innerHTML, "Unable to display any files." );
+
+    clock.tick( 4500 );
+    assert( spy.notCalled );
+    clock.tick( 500 );
+    assert( spy.calledOnce );
+
+    RiseVision.VideoRLS.play.restore();
+  } );
+
+} );

--- a/test/integration/js/player-local-storage-stubs.js
+++ b/test/integration/js/player-local-storage-stubs.js
@@ -1,0 +1,33 @@
+/* global top, RiseVision, sinon, messageHandlers, config */
+
+/* eslint-disable func-names, no-global-assign */
+
+var messageHandlers = [];
+
+config.TEST_USE_RLS = true;
+
+top.RiseVision = RiseVision || {};
+top.RiseVision.Viewer = {};
+top.RiseVision.Viewer.LocalMessaging = {
+  write: function() {
+    // console.log(message);
+  },
+  receiveMessages: function( action ) {
+    messageHandlers.push( function( data ) {
+      action( data );
+    } );
+  },
+  canConnect: function() {
+    return true;
+  }
+};
+
+sinon.stub( RiseVision.VideoRLS, "setAdditionalParams", function( params, mode, displayId ) {
+  ready = true; // eslint-disable-line no-undef
+  // spy on log call
+  logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" ); // eslint-disable-line no-undef
+
+  RiseVision.VideoRLS.setAdditionalParams.restore();
+  // override company id to be the same company from the test data to bypass making direct licensing authorization request
+  RiseVision.VideoRLS.setAdditionalParams( params, mode, displayId, "b428b4e8-c8b9-41d5-8a10-b4193c789443" );
+} );

--- a/test/integration/non-storage/logging.html
+++ b/test/integration/non-storage/logging.html
@@ -144,6 +144,8 @@
 
         params.event = "player error";
         params.event_details = "MEDIA_ERR_UNKNOWN - Sorry, there was a problem playing the video.";
+        // since RC not running, local_url is the same as file_url
+        params.local_url = params.file_url;
 
         RiseVision.Video.playerError();
 
@@ -215,6 +217,7 @@
         params.event = "non-storage error";
         params.event_details = "The request failed with status code: 0";
         params.file_url = "http://localhost:9494/?url=http%3A%2F%2Fs3.amazonaws.com%2Fstu-testing%2Fsample_videos%2Fbig-buck-bunny_trailer.webm";
+        delete params.local_url;
 
         nonStorage.init();
         requests[1].respond(0); // HEAD request

--- a/test/integration/player-local-storage/file.html
+++ b/test/integration/player-local-storage/file.html
@@ -45,37 +45,7 @@
 
 <script src="../../data/storage-file.js"></script>
 <script src="../js/player-local-storage-file.js"></script>
-<script>
-  var messageHandlers = [];
-
-  config.TEST_USE_RLS = true;
-
-  top.RiseVision = RiseVision || {};
-  top.RiseVision.Viewer = {};
-  top.RiseVision.Viewer.LocalMessaging = {
-    write: function() {
-      // console.log(message);
-    },
-    receiveMessages: function( action ) {
-      messageHandlers.push( function( data ) {
-        action( data );
-      } );
-    },
-    canConnect: function() {
-      return true;
-    }
-  };
-
-  sinon.stub( RiseVision.VideoRLS, "setAdditionalParams", function( params, mode, displayId ) {
-    ready = true;
-
-    RiseVision.VideoRLS.setAdditionalParams.restore();
-    RiseVision.VideoRLS.setAdditionalParams( params, mode, displayId );
-    // override company id to be the same company from the test data to bypass making direct licensing authorization request
-    RiseVision.VideoRLS.setAdditionalParams( params, mode, displayId, "b428b4e8-c8b9-41d5-8a10-b4193c789443" );
-  } );
-</script>
-
+<script src="../js/player-local-storage-stubs.js"></script>
 <script src="../../../src/widget/main.js"></script>
 
 </body>

--- a/test/integration/player-local-storage/folder-one-file.html
+++ b/test/integration/player-local-storage/folder-one-file.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Video Widget</title>
+
+  <script src="../../../src/components/web-component-tester/browser.js"></script>
+
+  <link rel="stylesheet" type="text/css" href="../../../src/components/videojs/dist/video-js.css">
+  <link rel="stylesheet" type="text/css" href="../../../src/widget/css/video.css">
+  <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
+</head>
+<body>
+
+<div id="container">
+  <video id="player" class="video-js" preload="auto"></video>
+</div>
+
+<div id="messageContainer"></div>
+
+<script src="../../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
+<script src="../../../node_modules/widget-tester/mocks/logger-mock.js"></script>
+
+<script src="../../../src/components/videojs/dist/video.min.js"></script>
+<script src="../../../src/components/underscore/underscore-min.js"></script>
+
+<script src="../../../src/components/widget-common/dist/config.js"></script>
+<script src="../../../src/components/widget-common/dist/common.js"></script>
+<script src="../../../src/common-modules/local-messaging.js"></script>
+<script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
+<script src="../../../src/components/widget-common/dist/message.js"></script>
+<script src="../../../src/config/version.js"></script>
+<script src="../../../src/config/test.js"></script>
+<script src="../../../src/widget/video-utils.js"></script>
+<script src="../../../src/widget/video-rls.js"></script>
+<script src="../../../src/widget/player-utils.js"></script>
+<script src="../../../src/widget/player-vjs.js"></script>
+<script src="../../../src/widget/player-local-storage-folder.js"></script>
+
+<script type="text/javascript">
+  config.COMPONENTS_PATH = "../../../src/components/";
+</script>
+
+<script src="../../data/storage-folder.js"></script>
+<script src="../js/player-local-storage-folder-one-file.js"></script>
+<script src="../js/player-local-storage-stubs.js"></script>
+<script src="../../../src/widget/main.js"></script>
+
+</body>
+</html>

--- a/test/integration/player-local-storage/folder.html
+++ b/test/integration/player-local-storage/folder.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Video Widget</title>
+
+  <script src="../../../src/components/web-component-tester/browser.js"></script>
+
+  <link rel="stylesheet" type="text/css" href="../../../src/components/videojs/dist/video-js.css">
+  <link rel="stylesheet" type="text/css" href="../../../src/widget/css/video.css">
+  <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
+</head>
+<body>
+
+<div id="container">
+  <video id="player" class="video-js" preload="auto"></video>
+</div>
+
+<div id="messageContainer"></div>
+
+<script src="../../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
+<script src="../../../node_modules/widget-tester/mocks/logger-mock.js"></script>
+
+<script src="../../../src/components/videojs/dist/video.min.js"></script>
+<script src="../../../src/components/underscore/underscore-min.js"></script>
+
+<script src="../../../src/components/widget-common/dist/config.js"></script>
+<script src="../../../src/components/widget-common/dist/common.js"></script>
+<script src="../../../src/common-modules/local-messaging.js"></script>
+<script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
+<script src="../../../src/components/widget-common/dist/message.js"></script>
+<script src="../../../src/config/version.js"></script>
+<script src="../../../src/config/test.js"></script>
+<script src="../../../src/widget/video-utils.js"></script>
+<script src="../../../src/widget/video-rls.js"></script>
+<script src="../../../src/widget/player-utils.js"></script>
+<script src="../../../src/widget/player-vjs.js"></script>
+<script src="../../../src/widget/player-local-storage-folder.js"></script>
+
+<script type="text/javascript">
+  config.COMPONENTS_PATH = "../../../src/components/";
+</script>
+
+<script src="../../data/storage-folder.js"></script>
+<script src="../js/player-local-storage-folder.js"></script>
+<script src="../js/player-local-storage-stubs.js"></script>
+<script src="../../../src/widget/main.js"></script>
+
+</body>
+</html>

--- a/test/integration/player-local-storage/logging-file.html
+++ b/test/integration/player-local-storage/logging-file.html
@@ -45,38 +45,7 @@
 
 <script src="../../data/storage-file.js"></script>
 <script src="../js/player-local-storage-logging-file.js"></script>
-<script>
-  var messageHandlers = [];
-
-  config.TEST_USE_RLS = true;
-
-  top.RiseVision = RiseVision || {};
-  top.RiseVision.Viewer = {};
-  top.RiseVision.Viewer.LocalMessaging = {
-    write: function() {
-      // console.log(message);
-    },
-    receiveMessages: function( action ) {
-      messageHandlers.push( function( data ) {
-        action( data );
-      } );
-    },
-    canConnect: function() {
-      return true;
-    }
-  };
-
-  sinon.stub( RiseVision.VideoRLS, "setAdditionalParams", function( params, mode, displayId ) {
-    ready = true;
-    // spy on log call
-    logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" ); // eslint-disable-line no-undef
-
-    RiseVision.VideoRLS.setAdditionalParams.restore();
-    // override company id to be the same company from the test data to bypass making direct licensing authorization request
-    RiseVision.VideoRLS.setAdditionalParams( params, mode, displayId, "b428b4e8-c8b9-41d5-8a10-b4193c789443" );
-  } );
-</script>
-
+<script src="../js/player-local-storage-stubs.js"></script>
 <script src="../../../src/widget/main.js"></script>
 
 </body>

--- a/test/integration/player-local-storage/logging-folder.html
+++ b/test/integration/player-local-storage/logging-folder.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Video Widget</title>
+
+  <script src="../../../src/components/web-component-tester/browser.js"></script>
+
+  <link rel="stylesheet" type="text/css" href="../../../src/components/videojs/dist/video-js.css">
+  <link rel="stylesheet" type="text/css" href="../../../src/widget/css/video.css">
+  <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
+</head>
+<body>
+
+<div id="container">
+  <video id="player" class="video-js" preload="auto"></video>
+</div>
+
+<div id="messageContainer"></div>
+
+<script src="../../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
+<script src="../../../node_modules/widget-tester/mocks/logger-mock.js"></script>
+
+<script src="../../../src/components/videojs/dist/video.min.js"></script>
+<script src="../../../src/components/underscore/underscore-min.js"></script>
+
+<script src="../../../src/components/widget-common/dist/config.js"></script>
+<script src="../../../src/components/widget-common/dist/common.js"></script>
+<script src="../../../src/common-modules/local-messaging.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
+<script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/components/widget-common/dist/message.js"></script>
+<script src="../../../src/config/version.js"></script>
+<script src="../../../src/config/test.js"></script>
+<script src="../../../src/widget/video-utils.js"></script>
+<script src="../../../src/widget/video-rls.js"></script>
+<script src="../../../src/widget/player-utils.js"></script>
+<script src="../../../src/widget/player-vjs.js"></script>
+<script src="../../../src/widget/player-local-storage-folder.js"></script>
+
+<script type="text/javascript">
+  config.COMPONENTS_PATH = "../../../src/components/";
+</script>
+
+<script src="../../data/storage-folder.js"></script>
+<script src="../js/player-local-storage-logging-folder.js"></script>
+<script src="../js/player-local-storage-stubs.js"></script>
+<script src="../../../src/widget/main.js"></script>
+
+</body>
+</html>

--- a/test/integration/player-local-storage/messaging-file.html
+++ b/test/integration/player-local-storage/messaging-file.html
@@ -45,35 +45,7 @@
 
 <script src="../../data/storage-file.js"></script>
 <script src="../js/player-local-storage-messaging-file.js"></script>
-<script>
-  var messageHandlers = [];
-
-  config.TEST_USE_RLS = true;
-
-  top.RiseVision = RiseVision || {};
-  top.RiseVision.Viewer = {};
-  top.RiseVision.Viewer.LocalMessaging = {
-    write: function() {
-      // console.log(message);
-    },
-    receiveMessages: function( action ) {
-      messageHandlers.push( function( data ) {
-        action( data );
-      } );
-    },
-    canConnect: function() {
-      return true;
-    }
-  };
-
-  sinon.stub( RiseVision.VideoRLS, "setAdditionalParams", function( params, mode, displayId ) {
-    ready = true;
-
-    RiseVision.VideoRLS.setAdditionalParams.restore();
-    // override company id to be the same company from the test data to bypass making direct licensing authorization request
-    RiseVision.VideoRLS.setAdditionalParams( params, mode, displayId, "b428b4e8-c8b9-41d5-8a10-b4193c789443" );
-  } );
-</script>
+<script src="../js/player-local-storage-stubs.js"></script>
 
 <script src="../../../src/widget/main.js"></script>
 

--- a/test/integration/player-local-storage/messaging-folder.html
+++ b/test/integration/player-local-storage/messaging-folder.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Video Widget</title>
+
+  <script src="../../../src/components/web-component-tester/browser.js"></script>
+
+  <link rel="stylesheet" type="text/css" href="../../../src/components/videojs/dist/video-js.css">
+  <link rel="stylesheet" type="text/css" href="../../../src/widget/css/video.css">
+  <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
+</head>
+<body>
+
+<div id="container">
+  <video id="player" class="video-js" preload="auto"></video>
+</div>
+
+<div id="messageContainer"></div>
+
+<script src="../../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
+<script src="../../../node_modules/widget-tester/mocks/logger-mock.js"></script>
+
+<script src="../../../src/components/videojs/dist/video.min.js"></script>
+<script src="../../../src/components/underscore/underscore-min.js"></script>
+
+<script src="../../../src/components/widget-common/dist/config.js"></script>
+<script src="../../../src/components/widget-common/dist/common.js"></script>
+<script src="../../../src/common-modules/local-messaging.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
+<script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/components/widget-common/dist/message.js"></script>
+<script src="../../../src/config/version.js"></script>
+<script src="../../../src/config/test.js"></script>
+<script src="../../../src/widget/video-utils.js"></script>
+<script src="../../../src/widget/video-rls.js"></script>
+<script src="../../../src/widget/player-utils.js"></script>
+<script src="../../../src/widget/player-vjs.js"></script>
+<script src="../../../src/widget/player-local-storage-folder.js"></script>
+
+<script type="text/javascript">
+  config.COMPONENTS_PATH = "../../../src/components/";
+</script>
+
+<script src="../../data/storage-folder.js"></script>
+<script src="../js/player-local-storage-messaging-folder.js"></script>
+<script src="../js/player-local-storage-stubs.js"></script>
+
+<script src="../../../src/widget/main.js"></script>
+
+</body>
+</html>

--- a/test/integration/video-utils.html
+++ b/test/integration/video-utils.html
@@ -34,6 +34,72 @@
 
     var videoUtils = RiseVision.VideoUtils;
 
+    suite( "getStorageSingleFilePath", function() {
+
+      teardown( function() {
+        videoUtils.setParams( null );
+      } );
+
+      test( "should provide single file path (bucket only)", function() {
+        videoUtils.setParams( {
+          storage: {
+            companyId: "abc123",
+            fileName: "test-file.jpg"
+          }
+        } );
+
+        assert.equal( videoUtils.getStorageSingleFilePath(), "risemedialibrary-abc123/test-file.jpg" );
+      } );
+
+      test( "should provide single file path (with subfolder)", function() {
+        videoUtils.setParams( {
+          storage: {
+            companyId: "abc123",
+            fileName: "test-file.jpg",
+            folder: "test-folder/nested-folder/"
+          }
+        } );
+
+        assert.equal( videoUtils.getStorageSingleFilePath(), "risemedialibrary-abc123/test-folder/nested-folder/test-file.jpg" );
+      } );
+
+    } );
+
+    suite( "getStorageFolderPath", function() {
+
+      teardown( function() {
+        videoUtils.setParams( null );
+      } );
+
+      test( "should provide folder path", function() {
+        videoUtils.setParams( {
+          storage: {
+            companyId: "abc123",
+            folder: "test-folder/"
+          }
+        } );
+
+        assert.equal( videoUtils.getStorageFolderPath(), "risemedialibrary-abc123/test-folder/" );
+      } );
+
+    } );
+
+    suite( "isValidDisplayId", function() {
+      test( "should return false when not a valid display id", function() {
+        videoUtils.setDisplayId( "preview" );
+        assert( !videoUtils.isValidDisplayId() );
+        videoUtils.setDisplayId( "display_id" );
+        assert( !videoUtils.isValidDisplayId() );
+        videoUtils.setDisplayId( "'displayId'" );
+        assert( !videoUtils.isValidDisplayId() );
+      } );
+
+      test( "should return true when is a valid display id", function() {
+        videoUtils.setDisplayId( "abc123" );
+        assert( videoUtils.isValidDisplayId( "abc123" ) );
+      } );
+    } );
+
     suite( "startErrorTimer", function() {
 
       test( "should after 5 seconds send done to Viewer", function() {

--- a/test/integration/video-utils.html
+++ b/test/integration/video-utils.html
@@ -120,14 +120,14 @@
 
     suite( "setCurrentFiles", function() {
 
-      test( "should handle string type (single file)", function() {
+      test( "should handle string type (non RLS single file)", function() {
         videoUtils.setCurrentFiles( "test-bucket/video.webm" );
 
         expect( videoUtils.getCurrentFiles().length ).to.equal( 1 );
         expect( videoUtils.getCurrentFiles()[ 0 ] ).to.equal( "test-bucket/video.webm" );
       } );
 
-      test( "should handle array type (folder)", function() {
+      test( "should handle array type (folder or RLS single file)", function() {
         videoUtils.setCurrentFiles( [ "test-bucket/video.webm", "test-bucket/video2.webm" ] );
 
         expect( videoUtils.getCurrentFiles().length ).to.equal( 2 );

--- a/test/unit/widget/video-utils-spec.js
+++ b/test/unit/widget/video-utils-spec.js
@@ -10,6 +10,16 @@ describe( "getTableName", function() {
   } );
 } );
 
+describe( "getStorageFileName", function() {
+  it( "should provide file name from storage file path (bucket only)", function() {
+    expect( RiseVision.VideoUtils.getStorageFileName( "risemedialibrary-abc123/test-file.jpg" ) ).to.equal( "test-file.jpg" );
+  } );
+
+  it( "should provide file name from storage file path (with subfolder)", function() {
+    expect( RiseVision.VideoUtils.getStorageFileName( "risemedialibrary-abc123/test-folder/nested-folder/test-file.jpg" ) ).to.equal( "test-file.jpg" );
+  } );
+} );
+
 describe( "logEvent", function() {
   var logSpy;
 

--- a/test/unit/widget/video-utils-spec.js
+++ b/test/unit/widget/video-utils-spec.js
@@ -44,8 +44,7 @@ describe( "logEvent", function() {
     var params = {
       "event": "test",
       "company_id": "",
-      "display_id": "",
-      "file_url": null
+      "display_id": ""
     };
 
     RiseVision.VideoUtils.logEvent( { "event": "test" } );


### PR DESCRIPTION
- In preview, falls back on using `rise-storage` web component
- On player, when configured for a storage folder and can use RLS (rollout), executes logic for using RLS. Otherwise, uses existing `rise-storage` and Rise Cache logic
- Added new `player-local-storage-folder.js` to handle all RLS folder scenarios
- Where applicable, code regarding folder is refactored to port reusable code into `video-utils.js` so it is shared between using RLS and not using RLS
- Logging implemented in all RLS folder scenarios
- Logging events improved for single file