### PR TITLE
Log configuration event prior to sending "ready" to Viewer [stage-2]

### DIFF
--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -22,6 +22,27 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
   /*
    *  Private Methods
    */
+  function _logConfiguration( type ) {
+    var configParams = {
+        "event": "configuration",
+        "event_details": type
+      },
+      mode = _videoUtils.getMode();
+
+    if ( !_configurationLogged ) {
+      if ( mode === "file" ) {
+        configParams.file_url = _videoUtils.getStorageSingleFilePath();
+      } else if ( mode === "folder" ) {
+        configParams.file_url = _videoUtils.getStorageFolderPath();
+        configParams.file_format = "WEBM|MP4|OGV|OGG";
+      }
+
+      _configurationLogged = true;
+
+      _videoUtils.logEvent( configParams );
+    }
+  }
+
   function _init() {
     var params = _videoUtils.getParams();
 
@@ -44,16 +65,16 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
 
         // create and initialize the Storage file instance
         _storage = new RiseVision.VideoRLS.PlayerLocalStorageFile();
-        _storage.init();
       } else if ( _videoUtils.getMode() === "folder" ) {
         _videoUtils.setConfigurationType( "storage folder (rls)" );
 
         // create and initialize the Storage folder instance
         _storage = new RiseVision.VideoRLS.PlayerLocalStorageFolder();
-        _storage.init();
       }
     }
 
+    _storage.init();
+    _logConfiguration( _videoUtils.getConfigurationType() );
     _videoUtils.sendReadyToViewer();
   }
 
@@ -115,26 +136,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
   }
 
   function play() {
-    var params = _videoUtils.getParams(),
-      configParams = {
-        "event": "configuration",
-        "event_details": _videoUtils.getConfigurationType()
-      },
-      mode = _videoUtils.getMode(),
-      currentFiles;
-
-    if ( !_configurationLogged ) {
-      if ( mode === "file" ) {
-        configParams.file_url = _videoUtils.getStorageSingleFilePath();
-      } else if ( mode === "folder" ) {
-        configParams.file_url = _videoUtils.getStorageFolderPath();
-        configParams.file_format = "WEBM|MP4|OGV|OGG";
-      }
-
-      _configurationLogged = true;
-
-      _videoUtils.logEvent( configParams );
-    }
+    var currentFiles;
 
     _viewerPaused = false;
 
@@ -158,7 +160,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
       currentFiles = _videoUtils.getCurrentFiles();
 
       if ( currentFiles && currentFiles.length > 0 ) {
-        _player = new RiseVision.PlayerVJS( params, _videoUtils.getMode(), RiseVision.VideoRLS );
+        _player = new RiseVision.PlayerVJS( _videoUtils.getParams(), _videoUtils.getMode(), RiseVision.VideoRLS );
         _player.init( currentFiles );
       }
     }

--- a/src/widget/video.js
+++ b/src/widget/video.js
@@ -31,6 +31,32 @@ RiseVision.Video = ( function( window, gadgets ) {
     _unavailableFlag = false;
   }
 
+  function _logConfiguration( type ) {
+    var params = _videoUtils.getParams(),
+      configParams = {
+        "event": "configuration",
+        "event_details": type
+      },
+      mode = _videoUtils.getMode();
+
+    if ( !_configurationLogged ) {
+      if ( mode === "file" ) {
+        if ( type !== "custom" ) {
+          configParams.file_url = _videoUtils.getStorageSingleFilePath();
+        } else {
+          configParams.file_url = ( params.url && params.url !== "" ) ? params.url : params.selector.url;
+        }
+
+      } else if ( mode === "folder" ) {
+        configParams.file_url = _videoUtils.getStorageFolderPath();
+        configParams.file_format = "WEBM|MP4|OGV|OGG";
+      }
+
+      _videoUtils.logEvent( configParams );
+      _configurationLogged = true;
+    }
+  }
+
   function _init() {
     var params = _videoUtils.getParams(),
       isStorageFile;
@@ -73,6 +99,7 @@ RiseVision.Video = ( function( window, gadgets ) {
       }
     }
 
+    _logConfiguration( _videoUtils.getConfigurationType() );
     _videoUtils.sendReadyToViewer();
   }
 
@@ -138,30 +165,7 @@ RiseVision.Video = ( function( window, gadgets ) {
   }
 
   function play() {
-    var params = _videoUtils.getParams(),
-      configParams = {
-        "event": "configuration",
-        "event_details": _videoUtils.getConfigurationType()
-      },
-      mode = _videoUtils.getMode(),
-      currentFiles;
-
-    if ( !_configurationLogged ) {
-      if ( mode === "file" ) {
-        if ( _videoUtils.getConfigurationType() !== "custom" ) {
-          configParams.file_url = _videoUtils.getStorageSingleFilePath();
-        } else {
-          configParams.file_url = ( params.url && params.url !== "" ) ? params.url : params.selector.url;
-        }
-
-      } else if ( mode === "folder" ) {
-        configParams.file_url = _videoUtils.getStorageFolderPath();
-        configParams.file_format = "WEBM|MP4|OGV|OGG";
-      }
-
-      _videoUtils.logEvent( configParams );
-      _configurationLogged = true;
-    }
+    var currentFiles;
 
     _viewerPaused = false;
 
@@ -189,7 +193,7 @@ RiseVision.Video = ( function( window, gadgets ) {
       currentFiles = _videoUtils.getCurrentFiles();
 
       if ( currentFiles && currentFiles.length > 0 ) {
-        _player = new RiseVision.PlayerVJS( params, _videoUtils.getMode(), RiseVision.Video );
+        _player = new RiseVision.PlayerVJS( _videoUtils.getParams(), _videoUtils.getMode(), RiseVision.Video );
         _player.init( currentFiles );
       }
     }


### PR DESCRIPTION
This will help in reviewing logs as it will ensure "configuration" event is logged prior to any other events (ie. error).