### PR TITLE
Fix getStorageFileName() util function to account for # or ? in file name

### DIFF
--- a/src/widget/video-utils.js
+++ b/src/widget/video-utils.js
@@ -30,7 +30,7 @@ RiseVision.VideoUtils = ( function() {
       return "";
     }
 
-    return filePath.split( "#" ).shift().split( "?" ).shift().split( "/" ).pop();
+    return filePath.split( "risemedialibrary-" ).pop().split( "/" ).pop();
   }
 
   function getCurrentFiles() {

--- a/test/unit/widget/video-utils-spec.js
+++ b/test/unit/widget/video-utils-spec.js
@@ -18,6 +18,20 @@ describe( "getStorageFileName", function() {
   it( "should provide file name from storage file path (with subfolder)", function() {
     expect( RiseVision.VideoUtils.getStorageFileName( "risemedialibrary-abc123/test-folder/nested-folder/test-file.jpg" ) ).to.equal( "test-file.jpg" );
   } );
+
+  it( "should provide file name from storage file path (bucket only) when name has special characters", function() {
+    expect( RiseVision.VideoUtils.getStorageFileName( "risemedialibrary-abc123/([!@?,#$])=1+2-A | <>.webm" ) ).to.equal( "([!@?,#$])=1+2-A | <>.webm" );
+    expect( RiseVision.VideoUtils.getStorageFileName( "risemedialibrary-abc123/test %.webm" ) ).to.equal( "test %.webm" );
+    expect( RiseVision.VideoUtils.getStorageFileName( "risemedialibrary-abc123/test *.webm" ) ).to.equal( "test *.webm" );
+    expect( RiseVision.VideoUtils.getStorageFileName( "risemedialibrary-abc123/test Ü.webm" ) ).to.equal( "test Ü.webm" );
+  } );
+
+  it( "should provide file name from storage file path (with subfolder) when name has special characters", function() {
+    expect( RiseVision.VideoUtils.getStorageFileName( "risemedialibrary-abc123/test-folder/nested-folder/([!@?,#$])=1+2-A | <>.webm" ) ).to.equal( "([!@?,#$])=1+2-A | <>.webm" );
+    expect( RiseVision.VideoUtils.getStorageFileName( "risemedialibrary-abc123/test-folder/nested-folder/test %.webm" ) ).to.equal( "test %.webm" );
+    expect( RiseVision.VideoUtils.getStorageFileName( "risemedialibrary-abc123/test-folder/nested-folder/test *.webm" ) ).to.equal( "test *.webm" );
+    expect( RiseVision.VideoUtils.getStorageFileName( "risemedialibrary-abc123/test-folder/nested-folder/test Ü.webm" ) ).to.equal( "test Ü.webm" );
+  } );
 } );
 
 describe( "logEvent", function() {


### PR DESCRIPTION
- Fixes issue #240 
- Presentation validated on my display YSD5WEDW339F - https://apps.risevision.com/editor/workspace/dce2352c-c43f-4bf0-a219-6e2c94f9d3f1/?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013