### PR TITLE
Do not show video when file(s) have been deleted

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,7 @@
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#v3.4.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
     "underscore": "~1.8.3",
-    "videojs-playlist": "^3.0.0",
+    "videojs-playlist": "3.1.1",
     "common-header": "https://github.com/Rise-Vision/common-header.git#v2.4.3",
     "webcomponentsjs": "v1.1.0"
   },

--- a/src/widget/player-local-storage-file.js
+++ b/src/widget/player-local-storage-file.js
@@ -131,6 +131,8 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       "event": "file deleted",
       "file_url": data.filePath
     } );
+
+    RiseVision.VideoRLS.onFileDeleted( data.filePath );
   }
 
   function _handleFileError( data ) {

--- a/src/widget/player-local-storage-folder.js
+++ b/src/widget/player-local-storage-folder.js
@@ -108,7 +108,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
         "file_format": "unknown"
       } );
 
-      RiseVision.VideoRLS.showError( "Unable to display any files." );
+      RiseVision.VideoRLS.onFolderFilesRemoved();
     } else {
       RiseVision.VideoRLS.onFileRefresh( files );
     }

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -166,7 +166,6 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     _playerInstance.on( "ended", _onEnded );
     _playerInstance.on( "error", _onError );
     _playerInstance.on( "loadedmetadata", _onLoadedMetaData );
-    _playerInstance.on( "dispose", _onDispose );
   }
 
   function _muteVideo() {
@@ -219,6 +218,10 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
   function dispose() {
     clearTimeout( _pauseTimer );
     _playerInstance.dispose();
+
+    setTimeout( function() {
+      _onDispose();
+    }, 500 );
   }
 
   function init( files ) {

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -64,6 +64,21 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     }
   }
 
+  function _onDispose() {
+    _autoPlay = false;
+    _playerInstance = null;
+    _files = null;
+    _fileCount = 0;
+    _utils = null;
+    _videoUtils = null;
+    _updateWaiting = false;
+    _isPaused = false;
+    _pauseTimer = null;
+    _pause = null;
+
+    videoRef.playerDisposed();
+  }
+
   function _onEnded() {
     if ( mode === "file" ) {
       _videoUtils.playerEnded();
@@ -151,6 +166,7 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     _playerInstance.on( "ended", _onEnded );
     _playerInstance.on( "error", _onError );
     _playerInstance.on( "loadedmetadata", _onLoadedMetaData );
+    _playerInstance.on( "dispose", _onDispose );
   }
 
   function _muteVideo() {
@@ -200,6 +216,11 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
   /*
    *  Public Methods
    */
+  function dispose() {
+    clearTimeout( _pauseTimer );
+    _playerInstance.dispose();
+  }
+
   function init( files ) {
     _files = files;
     _autoPlay = ( !params.video.controls ) ? true : params.video.autoplay;
@@ -220,7 +241,6 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     _removeLoadingSpinner();
 
   }
-
 
   /*
     Remove the loading spinner using video js api
@@ -284,6 +304,7 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
   }
 
   return {
+    "dispose": dispose,
     "init": init,
     "pause": pause,
     "play": play,

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -86,6 +86,10 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
   /*
    *  Public Methods
    */
+  function onFileDeleted() {
+    _player.dispose();
+  }
+
   function onFileInit( urls ) {
     _videoUtils.setCurrentFiles( urls );
 
@@ -164,6 +168,12 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
         _player.init( currentFiles );
       }
     }
+  }
+
+  function playerDisposed() {
+    _player = null;
+    _videoUtils.setCurrentFiles( [] );
+    showError( "The selected video has been moved to Trash." );
   }
 
   function playerError( error, localUrl, filePath ) {
@@ -254,8 +264,10 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     "onFileInit": onFileInit,
     "onFileRefresh": onFileRefresh,
     "onFileUnavailable": onFileUnavailable,
+    "onFileDeleted": onFileDeleted,
     "pause": pause,
     "play": play,
+    "playerDisposed": playerDisposed,
     "playerError": playerError,
     "playerReady": playerReady,
     "setAdditionalParams": setAdditionalParams,

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -87,7 +87,9 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
    *  Public Methods
    */
   function onFileDeleted() {
-    _player.dispose();
+    if ( _player ) {
+      _player.dispose();
+    }
   }
 
   function onFileInit( urls ) {
@@ -124,7 +126,9 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
   }
 
   function onFolderFilesRemoved() {
-    _player.dispose();
+    if ( _player ) {
+      _player.dispose();
+    }
   }
 
   function pause() {
@@ -230,7 +234,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     // Ensures loading messaging is hidden and video gets shown
     _message.hide();
 
-    if ( !_viewerPaused ) {
+    if ( !_viewerPaused && _player ) {
       _player.play();
     }
   }

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -123,6 +123,10 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     }
   }
 
+  function onFolderFilesRemoved() {
+    _player.dispose();
+  }
+
   function pause() {
     _viewerPaused = true;
 
@@ -173,7 +177,13 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
   function playerDisposed() {
     _player = null;
     _videoUtils.setCurrentFiles( [] );
-    showError( "The selected video has been moved to Trash." );
+
+    if ( _videoUtils.getMode() === "file" ) {
+      showError( "The selected video has been moved to Trash." );
+    } else if ( _videoUtils.getMode() === "folder" ) {
+      showError( "The selected folder does not contain any videos that can be played." );
+    }
+
   }
 
   function playerError( error, localUrl, filePath ) {
@@ -265,6 +275,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     "onFileRefresh": onFileRefresh,
     "onFileUnavailable": onFileUnavailable,
     "onFileDeleted": onFileDeleted,
+    "onFolderFilesRemoved": onFolderFilesRemoved,
     "pause": pause,
     "play": play,
     "playerDisposed": playerDisposed,

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -177,13 +177,13 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
   function playerDisposed() {
     _player = null;
     _videoUtils.setCurrentFiles( [] );
+    _videoUtils.resetVideoElement();
 
     if ( _videoUtils.getMode() === "file" ) {
       showError( "The selected video has been moved to Trash." );
     } else if ( _videoUtils.getMode() === "folder" ) {
       showError( "The selected folder does not contain any videos that can be played." );
     }
-
   }
 
   function playerError( error, localUrl, filePath ) {

--- a/src/widget/video-utils.js
+++ b/src/widget/video-utils.js
@@ -106,6 +106,19 @@ RiseVision.VideoUtils = ( function() {
     RiseVision.VideoUtils.sendDoneToViewer();
   }
 
+  function resetVideoElement() {
+    var container = document.getElementById( "container" ),
+      fragment = document.createDocumentFragment(),
+      el = document.createElement( "video" );
+
+    el.setAttribute( "id", "player" );
+    el.setAttribute( "preload", "auto" );
+    el.className = "video-js";
+
+    fragment.appendChild( el );
+    container.appendChild( fragment );
+  }
+
   function sendDoneToViewer() {
     gadgets.rpc.call( "", "rsevent_done", null, _prefs.getString( "id" ) );
   }
@@ -167,6 +180,7 @@ RiseVision.VideoUtils = ( function() {
     "isValidDisplayId": isValidDisplayId,
     "logEvent": logEvent,
     "playerEnded": playerEnded,
+    "resetVideoElement": resetVideoElement,
     "sendDoneToViewer": sendDoneToViewer,
     "sendReadyToViewer": sendReadyToViewer,
     "setConfigurationType": setConfigurationType,

--- a/src/widget/video-utils.js
+++ b/src/widget/video-utils.js
@@ -120,7 +120,7 @@ RiseVision.VideoUtils = ( function() {
       return;
     }
 
-    if ( Array.isArray( urls ) && urls.length > 0 ) {
+    if ( Array.isArray( urls ) ) {
       _currentFiles = urls;
     } else {
       _currentFiles[ 0 ] = urls;

--- a/test/integration/js/player-local-storage-file.js
+++ b/test/integration/js/player-local-storage-file.js
@@ -103,3 +103,29 @@ suite( "file changed", function() {
     } ), "onFileRefresh() called with correct data" );
   } );
 } );
+
+suite( "file deleted", function() {
+  setup( function() {
+    sinon.spy( RiseVision.VideoRLS, "onFileDeleted" );
+  } );
+
+  teardown( function() {
+    RiseVision.VideoRLS.onFileDeleted.restore();
+  } );
+
+  test( "should dispose of the video player", function() {
+    assert.equal( document.getElementsByTagName( "video" ).length, 1, "video player is showing" );
+
+    // mock receiving file-update to notify file is downloading
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+        status: "DELETED"
+      } );
+    } );
+
+    assert.equal( document.getElementsByTagName( "video" ).length, 0, "video player is not showing" );
+
+  } );
+} );

--- a/test/integration/js/player-local-storage-file.js
+++ b/test/integration/js/player-local-storage-file.js
@@ -105,16 +105,20 @@ suite( "file changed", function() {
 } );
 
 suite( "file deleted", function() {
+  var clock;
+
   setup( function() {
+    clock = sinon.useFakeTimers();
     sinon.spy( RiseVision.VideoRLS, "onFileDeleted" );
   } );
 
   teardown( function() {
     RiseVision.VideoRLS.onFileDeleted.restore();
+    clock.restore();
   } );
 
   test( "should dispose of the video player", function() {
-    assert.equal( document.getElementsByTagName( "video" ).length, 1, "video player is showing" );
+    assert.isNotNull( document.querySelector( "video#player_html5_api" ), "video player is showing" );
 
     // mock receiving file-update to notify file is downloading
     messageHandlers.forEach( function( handler ) {
@@ -125,7 +129,10 @@ suite( "file deleted", function() {
       } );
     } );
 
-    assert.equal( document.getElementsByTagName( "video" ).length, 0, "video player is not showing" );
+    clock.tick( 500 );
+
+    assert.isNotNull( document.querySelector( "video#player" ), "video element is showing" );
+    assert.isNull( document.querySelector( "video#player_html5_api" ), "video player is not showing" );
 
   } );
 } );

--- a/test/integration/js/player-local-storage-logging-file.js
+++ b/test/integration/js/player-local-storage-logging-file.js
@@ -187,6 +187,8 @@ suite( "errors", function() {
   } );
 
   test( "file deleted", function() {
+    var onDeleteStub = sinon.stub( RiseVision.VideoRLS, "onFileDeleted" );
+
     logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 
     messageHandlers.forEach( function( handler ) {
@@ -202,6 +204,8 @@ suite( "errors", function() {
 
     assert( logSpy.calledOnce );
     assert( logSpy.calledWith( table, params ) );
+
+    onDeleteStub.restore();
   } );
 
 } );

--- a/test/integration/js/player-local-storage-logging-folder.js
+++ b/test/integration/js/player-local-storage-logging-folder.js
@@ -273,7 +273,8 @@ suite( "errors", function() {
 
 suite( "folder file deleted", function() {
   test( "should log when a file in folder is deleted", function() {
-    var logParams = JSON.parse( JSON.stringify( params ) );
+    var logParams = JSON.parse( JSON.stringify( params ) ),
+      onFilesRemovedStub = sinon.stub( RiseVision.VideoRLS, "onFolderFilesRemoved" );
 
     logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 
@@ -325,6 +326,8 @@ suite( "folder file deleted", function() {
       display_id: params.display_id,
       version: params.version
     } ) );
+
+    onFilesRemovedStub.restore();
 
   } );
 } );

--- a/test/integration/js/player-local-storage-messaging-file.js
+++ b/test/integration/js/player-local-storage-messaging-file.js
@@ -135,6 +135,17 @@ suite( "errors", function() {
 } );
 
 suite( "file deleted", function() {
+
+  setup( function() {
+    sinon.stub( RiseVision.VideoRLS, "onFileDeleted", function() {
+      RiseVision.VideoRLS.playerDisposed();
+    } );
+  } );
+
+  teardown( function() {
+    RiseVision.VideoRLS.onFileDeleted.restore();
+  } );
+
   test( "file deleted", function() {
     // mock receiving file-update to notify file is downloading
     messageHandlers.forEach( function( handler ) {
@@ -165,7 +176,6 @@ suite( "file deleted", function() {
       } );
     } );
 
-    assert.isTrue( ( document.getElementById( "container" ).style.display === "block" ), "video container is showing" );
-    assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "none" ), "message container is hidden" );
+    assert.equal( document.querySelector( ".message" ).innerHTML, "The selected video has been moved to Trash." );
   } );
 } );

--- a/test/integration/js/player-local-storage-messaging-folder.js
+++ b/test/integration/js/player-local-storage-messaging-folder.js
@@ -161,12 +161,16 @@ suite( "file error", function() {
   setup( function() {
     sinon.stub( RiseVision.VideoRLS, "onFileInit" );
     sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+    sinon.stub( RiseVision.VideoRLS, "onFolderFilesRemoved", function() {
+      RiseVision.VideoRLS.playerDisposed();
+    } );
     clock = sinon.useFakeTimers();
   } );
 
   teardown( function() {
     RiseVision.VideoRLS.onFileInit.restore();
     RiseVision.VideoRLS.onFileRefresh.restore();
+    RiseVision.VideoRLS.onFolderFilesRemoved.restore();
     clock.restore();
   } );
 
@@ -212,7 +216,7 @@ suite( "file error", function() {
       } );
     } );
 
-    assert.equal( document.querySelector( ".message" ).innerHTML, "Unable to display any files." );
+    assert.equal( document.querySelector( ".message" ).innerHTML, "The selected folder does not contain any videos that can be played." );
 
     clock.tick( 4500 );
     assert( spy.notCalled );


### PR DESCRIPTION
- Disposing of VideoJS player when file deleted in single file configuration. 
- Disposing of VideoJS player when all files in a folder are unable to be played
  - all files were deleted
  - all files in folder are resulting in player error
- Accounting for no `dispose` event triggered due to using `5.11.1` version of VideoJS. Setting a delay to account for removing of DOM and other cleanup. 
- After disposing player instance, re-applying necessary `<video>` element back into container `<div>` in HTML 
- Forcing to use `3.1.1` of video-js-playlist plugin as they've introduced a breaking change by dropping Bower support. `3.1.1` is the last version used in production Video widget. 

Validated with staged version of Widget in Player for all scenarios. 