### PR TITLE
wait for load event on playlist plugin

### DIFF
--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -4,12 +4,26 @@
   "use strict";
 
   var id = new gadgets.Prefs().getString( "id" ),
+    isWaitingForScriptDependencies = false,
+    playOnceDependenciesAreLoaded = false,
     useRLS = false;
 
   // Disable context menu (right click menu)
   window.oncontextmenu = function() {
     return false;
   };
+
+  function _playlistDependencyLoaded() {
+    if ( isWaitingForScriptDependencies ) {
+      isWaitingForScriptDependencies = false;
+
+      if ( playOnceDependenciesAreLoaded ) {
+        playOnceDependenciesAreLoaded = false;
+
+        RiseVision.VideoRLS.play();
+      }
+    }
+  }
 
   function canUseRLSSingleFile() {
     try {
@@ -33,6 +47,20 @@
     }
 
     return false;
+  }
+
+
+  function _loadPlaylistPluginScript() {
+    var src = config.COMPONENTS_PATH + "videojs-playlist/dist/videojs-playlist.min.js",
+      script = document.createElement( "script" );
+
+    isWaitingForScriptDependencies = true;
+
+    script.async = false;
+    script.addEventListener( "load", _playlistDependencyLoaded );
+    script.src = src;
+
+    document.body.appendChild( script );
   }
 
   function configure( names, values ) {
@@ -65,7 +93,7 @@
           if ( !additionalParams.storage.fileName ) {
             // folder was selected
             mode = "folder";
-            RiseVision.Common.Utilities.loadScript( config.COMPONENTS_PATH + "videojs-playlist/dist/videojs-playlist.min.js" );
+            _loadPlaylistPluginScript();
 
             // TODO: trigger test coverage for RLS with folder
             useRLS = config.TEST_USE_RLS || canUseRLSFolder();
@@ -136,7 +164,11 @@
     if ( !useRLS ) {
       RiseVision.Video.play();
     } else {
-      RiseVision.VideoRLS.play();
+      if ( config.STORAGE_ENV === "test" || !isWaitingForScriptDependencies ) {
+        RiseVision.VideoRLS.play();
+      } else {
+        playOnceDependenciesAreLoaded = true;
+      }
     }
 
   }

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -155,6 +155,13 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
       playlist.push( playlistItem );
     } );
 
+    if ( !_playerInstance.playlist ) {
+      _videoUtils.logEvent( {
+        "event": "error",
+        "event_details": "Playlist plugin did not load"
+      } );
+    }
+
     _playerInstance.playlist( playlist );
   }
 


### PR DESCRIPTION
This is the proposed fix for the error.

I'm using two flags:
- isWaitingForScriptDependencies gets set if a download for playlist plugin has started on RLS folder mode, and it's not used otherwise. if it's set and play() is called, the action will be deferred and the second flag will be set.
- playOnceDependenciesAreLoaded: when set to true, it means that play was intended but the playlist plugin has not started. This means that play() should be run once the plugin starts later.

I've tested it manually on both Chrome OS and Electron Players.

I added also an error log that will send an entry to BQ if it ever happens again that the playlist is not loaded when it's needed, as an extra check that will let us know if the problem presents again; but the event handling added here should be enough.

I had some problems with integration testing that relied on play being called directly, I added a test check for the time being. The test that give trouble was specifically this:
https://github.com/Rise-Vision/widget-video/blob/master/test/integration/js/player-local-storage-messaging-folder.js#L224
It seems that as now play may not be called if the script has not loaded, RiseVision.VideoRLS.play may not be called as is expected by this test.
