### PR TITLE
Stop displaying error for folder NOEXIST and EMPTYFOLDER messages

### DIFF
--- a/src/widget/player-local-storage-folder.js
+++ b/src/widget/player-local-storage-folder.js
@@ -245,7 +245,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
 
     videoUtils.logEvent( params );
 
-    RiseVision.VideoRLS.showError( "The selected folder does not exist or has been moved to Trash." );
+    RiseVision.VideoRLS.onFolderUnavailable();
   }
 
   function _handleFolderEmpty() {
@@ -258,7 +258,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
 
     videoUtils.logEvent( params );
 
-    RiseVision.VideoRLS.showError( "The selected folder does not contain any videos." );
+    RiseVision.VideoRLS.onFolderUnavailable();
   }
 
   function _handleFileDeleted( data ) {

--- a/src/widget/player-local-storage-folder.js
+++ b/src/widget/player-local-storage-folder.js
@@ -237,7 +237,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
 
   function _handleFolderNoExist() {
     var params = {
-      "event": "error",
+      "event": "warning",
       "event_details": "folder does not exist",
       "file_url": folderPath,
       "file_format": defaultFileFormat

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -17,7 +17,8 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     _storage = null,
     _resume = true,
     _errorFlag = false,
-    _unavailableFlag = false;
+    _unavailableFlag = false,
+    _folderUnavailableFlag = false;
 
   /*
    *  Private Methods
@@ -81,6 +82,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
   function _resetErrorFlags() {
     _errorFlag = false;
     _unavailableFlag = false;
+    _folderUnavailableFlag = false;
   }
 
   /*
@@ -131,6 +133,17 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     }
   }
 
+  function onFolderUnavailable() {
+    _folderUnavailableFlag = true;
+
+    // set to a blank message so the image container gets hidden and nothing is displayed on screen
+    _message.show( "" );
+
+    if ( !_viewerPaused ) {
+      _videoUtils.sendDoneToViewer();
+    }
+  }
+
   function pause() {
     _viewerPaused = true;
 
@@ -163,6 +176,12 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
       return;
     }
 
+    if ( _folderUnavailableFlag ) {
+      _videoUtils.sendDoneToViewer();
+
+      return;
+    }
+
     if ( _player ) {
       // Ensures possible error messaging gets hidden and video gets shown
       _message.hide();
@@ -186,7 +205,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     if ( _videoUtils.getMode() === "file" ) {
       showError( "The selected video has been moved to Trash." );
     } else if ( _videoUtils.getMode() === "folder" ) {
-      showError( "The selected folder does not contain any videos that can be played." );
+      onFolderUnavailable();
     }
   }
 
@@ -280,6 +299,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     "onFileUnavailable": onFileUnavailable,
     "onFileDeleted": onFileDeleted,
     "onFolderFilesRemoved": onFolderFilesRemoved,
+    "onFolderUnavailable": onFolderUnavailable,
     "pause": pause,
     "play": play,
     "playerDisposed": playerDisposed,

--- a/test/integration/js/player-local-storage-logging-folder.js
+++ b/test/integration/js/player-local-storage-logging-folder.js
@@ -120,7 +120,9 @@ suite( "errors", function() {
 
   } );
 
-  test( "folder does not exist", function() {
+  test( "file error", function() {
+    var logParams;
+
     logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 
     // mock receiving storage-licensing message
@@ -134,27 +136,6 @@ suite( "errors", function() {
 
     messageHandlers.forEach( function( handler ) {
       handler( {
-        topic: "file-update",
-        filePath: params.file_url,
-        status: "NOEXIST"
-      } );
-    } );
-
-    params.event = "error";
-    params.event_details = "folder does not exist";
-
-    assert( logSpy.calledOnce );
-    assert( logSpy.calledWith( table, params ) );
-
-  } );
-
-  test( "file error", function() {
-    var logParams;
-
-    logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
-
-    messageHandlers.forEach( function( handler ) {
-      handler( {
         topic: "file-error",
         filePath: params.file_url + "test-file-in-error.webm",
         msg: "Could not retrieve signed URL",
@@ -165,6 +146,7 @@ suite( "errors", function() {
     logParams = JSON.parse( JSON.stringify( params ) );
     logParams.file_url = params.file_url + "test-file-in-error.webm";
     logParams.file_format = "webm";
+    logParams.event = "error";
     logParams.event_details = "Could not retrieve signed URL | error details";
 
     assert( logSpy.calledOnce );
@@ -259,7 +241,7 @@ suite( "errors", function() {
       } );
     } );
 
-    logParams.event = params.event;
+    logParams.event = "error";
     logParams.file_url = params.file_url + "test-file-in-error-2.webm";
     logParams.file_format = "webm";
     logParams.event_details = "Could not retrieve signed URL | error details";
@@ -333,6 +315,25 @@ suite( "folder file deleted", function() {
 } );
 
 suite( "folder is empty", function() {
+
+  test( "should log a warning when folder does not exist", function() {
+    logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-update",
+        filePath: params.file_url,
+        status: "NOEXIST"
+      } );
+    } );
+
+    params.event = "warning";
+    params.event_details = "folder does not exist";
+
+    assert( logSpy.calledOnce );
+    assert( logSpy.calledWith( table, params ) );
+
+  } );
 
   test( "should log a warning when a folder is empty", function() {
     var logParams = JSON.parse( JSON.stringify( params ) );

--- a/test/integration/js/player-local-storage-messaging-folder.js
+++ b/test/integration/js/player-local-storage-messaging-folder.js
@@ -1,5 +1,4 @@
-/* global suiteSetup, suite, setup, teardown, test, assert,
- RiseVision, sinon */
+/* global suiteSetup, suite, setup, teardown, test, assert, sinon */
 
 /* eslint-disable func-names */
 
@@ -80,8 +79,20 @@ suite( "errors", function() {
 
     assert.equal( document.querySelector( ".message" ).innerHTML, "Rise Storage subscription is not active." );
   } );
+} );
 
-  test( "folder does not exist", function() {
+suite( "files downloading", function() {
+
+  setup( function() {
+    clock = sinon.useFakeTimers();
+  } );
+
+  teardown( function() {
+    clock.restore();
+  } );
+
+  test( "should show message after 15 seconds of processing", function() {
+
     // mock receiving storage-licensing message
     messageHandlers.forEach( function( handler ) {
       handler( {
@@ -98,37 +109,6 @@ suite( "errors", function() {
         status: "NOEXIST"
       } );
     } );
-
-    assert.equal( document.querySelector( ".message" ).innerHTML, "The selected folder does not exist or has been moved to Trash." );
-  } );
-
-  test( "folder is empty", function() {
-
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "file-update",
-        filePath: folderPath,
-        status: "EMPTYFOLDER"
-      } );
-    } );
-
-    assert.equal( document.querySelector( ".message" ).innerHTML, "The selected folder does not contain any videos." );
-
-  } );
-
-} );
-
-suite( "files downloading", function() {
-
-  setup( function() {
-    clock = sinon.useFakeTimers();
-  } );
-
-  teardown( function() {
-    clock.restore();
-  } );
-
-  test( "should show message after 15 seconds of processing", function() {
 
     // files are getting processed, starts the initial processing timer
     messageHandlers.forEach( function( handler ) {
@@ -152,78 +132,6 @@ suite( "files downloading", function() {
 
     assert.equal( document.querySelector( ".message" ).innerHTML, "Files are downloading." );
 
-  } );
-
-} );
-
-suite( "file error", function() {
-
-  setup( function() {
-    sinon.stub( RiseVision.VideoRLS, "onFileInit" );
-    sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
-    sinon.stub( RiseVision.VideoRLS, "onFolderFilesRemoved", function() {
-      RiseVision.VideoRLS.playerDisposed();
-    } );
-    clock = sinon.useFakeTimers();
-  } );
-
-  teardown( function() {
-    RiseVision.VideoRLS.onFileInit.restore();
-    RiseVision.VideoRLS.onFileRefresh.restore();
-    RiseVision.VideoRLS.onFolderFilesRemoved.restore();
-    clock.restore();
-  } );
-
-  test( "should display message when all files in error", function() {
-    var spy = sinon.spy( RiseVision.VideoRLS, "play" );
-
-    // successfully initialize widget and clear messages
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "FILE-UPDATE",
-        filePath: folderPath + "test-file.webm",
-        status: "CURRENT",
-        ospath: "path/to/file/abc123",
-        osurl: "file:///path/to/file/abc123"
-      } );
-    } );
-
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "FILE-UPDATE",
-        filePath: folderPath + "test-file-2.webm",
-        status: "CURRENT",
-        ospath: "path/to/file/def456",
-        osurl: "file:///path/to/file/def456"
-      } );
-    } );
-
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "file-error",
-        filePath: folderPath + "test-file.webm",
-        msg: "File's host server could not be reached",
-        detail: "error details"
-      } );
-    } );
-
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "file-error",
-        filePath: folderPath + "test-file-2.webm",
-        msg: "File's host server could not be reached",
-        detail: "error details"
-      } );
-    } );
-
-    assert.equal( document.querySelector( ".message" ).innerHTML, "The selected folder does not contain any videos that can be played." );
-
-    clock.tick( 4500 );
-    assert( spy.notCalled );
-    clock.tick( 500 );
-    assert( spy.calledOnce );
-
-    RiseVision.VideoRLS.play.restore();
   } );
 
 } );


### PR DESCRIPTION
- In either situation of folder doesn't exist or folder is empty, behaviour now is to continue to log to BQ but immediately notify Viewer `done` and do not display anything on screen. 
- Downgrading folder doesn't exist scenario to a warning, it shouldn't impact our reliability as it is a user controlled scenario. 
- Fix for issue https://github.com/Rise-Vision/rise-launcher-electron/issues/773