### PR TITLE
Retry playing video after MEDIA_DECODE error

### DIFF
--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -106,13 +106,13 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
         _decodeRetryCount += 1;
         _updateWaiting = true;
 
-        if ( !_isPaused ) {
-          // delay 1 second and then force a play()
-          setTimeout( function() {
+        // delay 1 second and then force a play()
+        setTimeout( function() {
+          if ( !_isPaused ) {
             console.log( "DECODE error, not paused, retry play() " );
             play();
-          }, 1000 );
-        }
+          }
+        }, 1000 );
 
         return;
       }


### PR DESCRIPTION
- Retry playing the video when a MEDIA_DECODE error occurs, every 1 second, max 5 attempts
- Listening for `play` videojs event to reset the decode retry count
- Fix for issue #256 