### PR TITLE
Rely on vjs playlist api for current index of playlist item being played

### DIFF
--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -9,7 +9,6 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
   var _autoPlay = false,
     _playerInstance = null,
     _files = null,
-    _fileCount = 0,
     _decodeRetryCount = 0,
     _utils = RiseVision.PlayerUtils,
     _videoUtils = RiseVision.VideoUtils,
@@ -70,7 +69,6 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     _autoPlay = false;
     _playerInstance = null;
     _files = null;
-    _fileCount = 0;
     _utils = null;
     _videoUtils = null;
     _updateWaiting = false;
@@ -85,10 +83,7 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     if ( mode === "file" ) {
       _videoUtils.playerEnded();
     } else if ( mode === "folder" ) {
-      _fileCount++;
-
-      if ( ( _fileCount >= _playerInstance.playlist().length ) ) {
-        _fileCount = 0;
+      if ( _playerInstance.playlist.currentItem() >= ( _playerInstance.playlist().length - 1 ) ) {
         _playerInstance.playlist.currentItem( 0 );
         _videoUtils.playerEnded();
       } else {


### PR DESCRIPTION
The `fileCount` value used in player-vjs.js is getting out of sync with the current playlist. It is not exactly known why but it looks to be the reason behind the defect https://github.com/Rise-Vision/chrome-os-player/issues/184 .

To avoid this, the more reliable approach instead of using the `fileCount` counter is to obtain what the current index of the playlist is in order to compare to the length of the list, which can be done via playlist api `playlist.currentItem()`. This will ensure an accurate current index value. 