### PR TITLE
Fix/update cci build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,8 @@ version: 2
 jobs:
   preconditions:
     working_directory: ~/Rise-Vision/widget-video
-    shell: /bin/bash --login
     docker: &BUILDIMAGE
-      - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-        command: /sbin/init
+      - image: jenkinsrise/cci-v2-transitional-widgets:0.0.4
     steps:
       - checkout
       - run: |
@@ -24,7 +22,6 @@ jobs:
 
   setup:
     working_directory: ~/Rise-Vision/widget-video
-    shell: /bin/bash --login
     environment:
       awscli: /home/ubuntu/aws/bin/aws
     docker: *BUILDIMAGE
@@ -32,8 +29,6 @@ jobs:
       - checkout
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
-      - run: nvm install 6.9.1 && nvm alias default 6.9.1
-      - run: npm install -g gulp bower
       - run: npm install
       - run: bower install
       - save_cache:
@@ -59,26 +54,8 @@ jobs:
           paths:
             - gcloud
 
-  aws-setup:
-    docker: *BUILDIMAGE
-    steps:
-      - restore_cache:
-          key: aws-cache2
-      - run: |
-          if [[ ! -d /home/ubuntu/aws ]]
-          then
-            sudo apt-get update
-            sudo apt-get install python-dev
-            curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && unzip awscli-bundle.zip && sudo ./awscli-bundle/install -i /home/ubuntu/aws
-          fi
-      - save_cache:
-          key: aws-cache2
-          paths:
-            - /home/ubuntu/aws
-
   test:
     working_directory: ~/Rise-Vision/widget-video
-    shell: /bin/bash --login
     docker: *BUILDIMAGE
     steps:
       - checkout
@@ -86,17 +63,10 @@ jobs:
           at: .
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
-      # latest stable chrome
-      - run: curl -L -o google-chrome-stable.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-      - run: sudo dpkg -i google-chrome-stable.deb
-      # make chrome lxc-friendly
-      - run: sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
-      - run: nvm install 6.9.1 && nvm alias default 6.9.1
       - run: NODE_ENV=dev npm run test
 
   build:
     working_directory: ~/Rise-Vision/widget-video
-    shell: /bin/bash --login
     docker: *BUILDIMAGE
     steps:
       - checkout
@@ -104,7 +74,6 @@ jobs:
           at: .
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
-      - run: nvm install 6.9.1 && nvm alias default 6.9.1
       - run: |
           if [ "${CIRCLE_BRANCH}" != "master" ]; then
             NODE_ENV=test npm run build
@@ -120,16 +89,13 @@ jobs:
             - test_dist
 
   stage-aws-dev:
-    shell: /bin/bash --login
     environment:
-      awscli: /home/ubuntu/aws/bin/aws
+      awscli: /usr/local/bin/aws
     docker: *BUILDIMAGE
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - restore_cache:
-          key: aws-cache2
       - run: |
           STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')"
           if [ "$STAGE_ENV" != '' ]
@@ -144,7 +110,6 @@ jobs:
           $awscli s3 sync ./test_dist s3://$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist --delete --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 
   stage-gcs-dev:
-    shell: /bin/bash --login
     docker: *GCSIMAGE
     steps:
       - checkout
@@ -165,16 +130,13 @@ jobs:
           gsutil rsync -d -r test_dist gs://widgets.risevision.com/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
 
   stage-aws-prod:
-    shell: /bin/bash --login
     environment:
-      awscli: /home/ubuntu/aws/bin/aws
+      awscli: /usr/local/bin/aws
     docker: *BUILDIMAGE
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - restore_cache:
-          key: aws-cache2
       - run: |
           STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')"
           if [ "$STAGE_ENV" != '' ]
@@ -188,7 +150,6 @@ jobs:
           $awscli s3 sync ./dist s3://$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist --delete --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 
   stage-gcs-prod:
-    shell: /bin/bash --login
     docker: *GCSIMAGE
     steps:
       - checkout
@@ -210,22 +171,18 @@ jobs:
           gsutil acl -r ch -u AllUsers:R gs://widgets.risevision.com/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
 
   deploy-aws-stable:
-    shell: /bin/bash --login
     environment:
-      awscli: /home/ubuntu/aws/bin/aws
+      awscli: /usr/local/bin/aws
     docker: *BUILDIMAGE
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - restore_cache:
-          key: aws-cache2
       - run: echo Deploying version $(grep version package.json |grep -o '[0-9.]*') to $BUCKET_NAME
       - run: $awscli s3 ls s3://$BUCKET_NAME || ($awscli s3 mb s3://$BUCKET_NAME && $awscli s3api put-bucket-acl --bucket $BUCKET_NAME --grant-read 'uri="http://acs.amazonaws.com/groups/global/AllUsers"')
       - run: $awscli s3 sync ./dist s3://$BUCKET_NAME/$(grep version package.json |grep -o '[0-9.]*')/dist --delete --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 
   deploy-gcs-stable:
-    shell: /bin/bash --login
     docker: *GCSIMAGE
     steps:
       - checkout
@@ -240,7 +197,6 @@ jobs:
       - run: ./upload-dist.sh
 
   test-memory:
-    shell: /bin/bash --login
     docker: *GCSIMAGE
     steps:
       - run: mkdir -p ~/.ssh
@@ -248,7 +204,6 @@ jobs:
       - run: ssh widget-memory-tester@104.197.26.57 'cd widget-memory-tester; DISPLAY=:10 DISPLAY_ID=MGAU442Y3CV9 RUNNING_TIME=3600000 gulp test > /dev/null &'
 
   generate-artifacts:
-    shell: /bin/bash --login
     docker: *BUILDIMAGE
     steps:
       - checkout
@@ -266,9 +221,6 @@ workflows:
       - setup:
           requires:
             - preconditions
-      - aws-setup:
-          requires:
-            - preconditions
       - gcloud-setup:
           requires:
             - preconditions
@@ -281,7 +233,6 @@ workflows:
       - stage-aws-dev:
           requires:
             - build
-            - aws-setup
           filters:
             branches:
               only:
@@ -297,7 +248,6 @@ workflows:
       - stage-aws-prod:
           requires:
             - build
-            - aws-setup
           filters:
             branches:
               only:
@@ -313,7 +263,6 @@ workflows:
       - deploy-aws-stable:
           requires:
             - build
-            - aws-setup
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
           $awscli s3 sync ./test_dist s3://$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist --delete --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 
   stage-gcs-dev:
+    shell: /bin/bash --login
     docker: *GCSIMAGE
     steps:
       - checkout
@@ -152,6 +153,7 @@ jobs:
           $awscli s3 sync ./dist s3://$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist --delete --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 
   stage-gcs-prod:
+    shell: /bin/bash --login
     docker: *GCSIMAGE
     steps:
       - checkout
@@ -186,6 +188,7 @@ jobs:
       - run: $awscli s3 sync ./dist s3://$BUCKET_NAME/$(grep version package.json |grep -o '[0-9.]*')/dist --delete --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 
   deploy-gcs-stable:
+    shell: /bin/bash --login
     docker: *GCSIMAGE
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ jobs:
             - test_dist
 
   stage-aws-dev:
+    shell: /bin/bash --login
     environment:
       awscli: /usr/local/bin/aws
     docker: *BUILDIMAGE
@@ -130,6 +131,7 @@ jobs:
           gsutil rsync -d -r test_dist gs://widgets.risevision.com/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
 
   stage-aws-prod:
+    shell: /bin/bash --login
     environment:
       awscli: /usr/local/bin/aws
     docker: *BUILDIMAGE
@@ -171,6 +173,7 @@ jobs:
           gsutil acl -r ch -u AllUsers:R gs://widgets.risevision.com/$BUCKET_NAME-test/$STAGE_ENV/$(grep version package.json |grep -o '[0-9.]*')/dist
 
   deploy-aws-stable:
+    shell: /bin/bash --login
     environment:
       awscli: /usr/local/bin/aws
     docker: *BUILDIMAGE

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Description
+Include a summary of the change. If this is fixing a defect, ensure to link to the issue this is fixing.
+
+## Motivation and Context
+Why is this change required? What problem does it solve?
+
+## How Has This Been Tested?
+Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.
+
+## Release Plan:
+- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
+- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
+
+#### Release Checklist Items Skipped?
+If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/Rise-Vision/widget-video.git"
   },
   "author": "Rise Vision",
-  "license": "GPLv3",
+  "license": "GPL-3.0+",
   "bugs": {
     "url": "https://github.com/Rise-Vision/widget-video/issues"
   },


### PR DESCRIPTION
## Description
Update CCI docker image for widget-video

## Motivation and Context
CCI builds are failing for widget-video, so this implements a fix similar to:
https://github.com/Rise-Vision/widget-google-calendar/pull/138/files

## How Has This Been Tested?
Running the build procedure.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
     No changes to the components are performed, and current build is failing anyhow. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation, no need to notify support, no automated tests needed.