### PR TITLE
Fix/issue 817 player disposal

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -210,8 +210,17 @@
     ]}
   ));
 
+  gulp.task("test:unit:video-rls", factory.testUnitAngular(
+    {testFiles: [
+      "node_modules/widget-tester/mocks/gadget-mocks.js",
+      "src/widget/video-utils.js",
+      "src/widget/video-rls.js",
+      "test/unit/widget/video-rls-spec.js"
+    ]}
+  ));
+
   gulp.task("test:unit:player", function(cb) {
-    runSequence("test:unit:player-utils", "test:unit:player-main", cb);
+    runSequence("test:unit:player-utils", "test:unit:player-main", "test:unit:video-rls", cb);
   });
 
   gulp.task("test:unit:widget", factory.testUnitAngular(

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -116,7 +116,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     // in case refreshed file fixes an error with previous file, ensure flag is removed so playback is attempted again
     _resetErrorFlags();
 
-    if ( !_player && _videoUtils.getCurrentFiles().length > 0 ) {
+    if ( !_viewerPaused && !_player && _videoUtils.getCurrentFiles().length > 0 ) {
       play();
     }
   }

--- a/src/widget/video-rls.js
+++ b/src/widget/video-rls.js
@@ -115,6 +115,10 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
 
     // in case refreshed file fixes an error with previous file, ensure flag is removed so playback is attempted again
     _resetErrorFlags();
+
+    if ( !_player && _videoUtils.getCurrentFiles().length > 0 ) {
+      play();
+    }
   }
 
   function onFileUnavailable( message ) {

--- a/test/unit/widget/video-rls-spec.js
+++ b/test/unit/widget/video-rls-spec.js
@@ -1,0 +1,66 @@
+/* global describe, before, after, it, expect, sinon, RiseVision */
+
+/* eslint-disable func-names */
+
+"use strict";
+
+describe( "onFileRefresh", function() {
+  var player;
+
+  beforeEach( function() {
+    player = {
+      init: sinon.spy()
+    };
+
+    RiseVision.PlayerVJS = function() {
+      return player;
+    }
+
+    sinon.stub( RiseVision.VideoUtils, "resetVideoElement" );
+  } );
+
+  afterEach( function() {
+    RiseVision.VideoUtils.resetVideoElement.restore();
+  } );
+
+  it( "should not play if viewer is paused", function() {
+    RiseVision.VideoRLS.onFileRefresh([ "url1" ]);
+
+    expect( player.init ).to.not.have.been.called;
+  } );
+
+  it( "should play if a file is added after player disposal if viewer is not paused", function() {
+    RiseVision.VideoUtils.setCurrentFiles([ "url1" ]);
+
+    RiseVision.VideoRLS.play();
+    expect( player.init ).to.have.been.calledWith([ "url1" ]);
+    expect( player.init ).to.have.been.called.once;
+
+    // this is called after folder is emptied
+    RiseVision.VideoRLS.playerDisposed();
+
+    // notify the folder has files again
+    RiseVision.VideoRLS.onFileRefresh([ "url2" ]);
+    expect( player.init ).to.have.been.calledWith([ "url2" ]);
+    expect( player.init ).to.have.been.called.twice;
+
+    // Cleanup
+    RiseVision.VideoRLS.playerDisposed();
+  } );
+
+  it( "should not play no files are added after player disposal even if viewer is not paused", function() {
+    RiseVision.VideoUtils.setCurrentFiles([ "url1" ]);
+
+    RiseVision.VideoRLS.play();
+    expect( player.init ).to.have.been.calledWith([ "url1" ]);
+    expect( player.init ).to.have.been.called.once;
+
+    // this is called after folder is emptied
+    RiseVision.VideoRLS.playerDisposed();
+
+    // notify the folder still has no files
+    RiseVision.VideoRLS.onFileRefresh([]);
+    expect( player.init ).to.have.been.called.once;
+  } );
+
+} );

--- a/test/unit/widget/video-rls-spec.js
+++ b/test/unit/widget/video-rls-spec.js
@@ -1,4 +1,4 @@
-/* global describe, before, after, it, expect, sinon, RiseVision */
+/* global describe, beforeEach, afterEach, it, expect, sinon, RiseVision */
 
 /* eslint-disable func-names */
 
@@ -24,24 +24,24 @@ describe( "onFileRefresh", function() {
   } );
 
   it( "should not play if viewer is paused", function() {
-    RiseVision.VideoRLS.onFileRefresh([ "url1" ]);
+    RiseVision.VideoRLS.onFileRefresh( [ "url1" ] );
 
     expect( player.init ).to.not.have.been.called;
   } );
 
   it( "should play if a file is added after player disposal if viewer is not paused", function() {
-    RiseVision.VideoUtils.setCurrentFiles([ "url1" ]);
+    RiseVision.VideoUtils.setCurrentFiles( [ "url1" ] );
 
     RiseVision.VideoRLS.play();
-    expect( player.init ).to.have.been.calledWith([ "url1" ]);
+    expect( player.init ).to.have.been.calledWith( [ "url1" ] );
     expect( player.init ).to.have.been.called.once;
 
     // this is called after folder is emptied
     RiseVision.VideoRLS.playerDisposed();
 
     // notify the folder has files again
-    RiseVision.VideoRLS.onFileRefresh([ "url2" ]);
-    expect( player.init ).to.have.been.calledWith([ "url2" ]);
+    RiseVision.VideoRLS.onFileRefresh( [ "url2" ] );
+    expect( player.init ).to.have.been.calledWith( [ "url2" ] );
     expect( player.init ).to.have.been.called.twice;
 
     // Cleanup
@@ -49,17 +49,17 @@ describe( "onFileRefresh", function() {
   } );
 
   it( "should not play no files are added after player disposal even if viewer is not paused", function() {
-    RiseVision.VideoUtils.setCurrentFiles([ "url1" ]);
+    RiseVision.VideoUtils.setCurrentFiles( [ "url1" ] );
 
     RiseVision.VideoRLS.play();
-    expect( player.init ).to.have.been.calledWith([ "url1" ]);
+    expect( player.init ).to.have.been.calledWith( [ "url1" ] );
     expect( player.init ).to.have.been.called.once;
 
     // this is called after folder is emptied
     RiseVision.VideoRLS.playerDisposed();
 
     // notify the folder still has no files
-    RiseVision.VideoRLS.onFileRefresh([]);
+    RiseVision.VideoRLS.onFileRefresh( [] );
     expect( player.init ).to.have.been.called.once;
   } );
 


### PR DESCRIPTION
## Description
Fixes video not being played when an empty folder gets a new video
Issue https://github.com/Rise-Vision/rise-launcher-electron/issues/817

## Motivation and Context
If a folder gets emptied, the _player reference is deleted here: https://github.com/Rise-Vision/widget-video/blob/master/src/widget/video-rls.js#L132

If after that a file is added to a folder, the update is received here: https://github.com/Rise-Vision/widget-video/blob/master/src/widget/video-rls.js#L109

but if the _player reference is null, then the video won't be shown. If the schedule pauses and shows again the widget, the video plays fine; but if this happens in a schedule with no other presentations, then the video won't ever show again unless player is restarted.

To solve that, logic was added to the onFileRefresh event, so the play() function i called when the presentation is visible and there are files. The play() function will create a new _player object if there is none.

## How Has This Been Tested?
Manually tested using this schedule: https://apps.risevision.com/schedules/details/710a1da0-8e90-43f4-9836-f8dfbdb03fae?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

The video presentation points to this video folder:  
https://apps.risevision.com/storage?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

If the folder is emptied and then new videos are uploaded, the player will play them right after download if the presentation is visible, and will also play them if they are added when the presentation is not visible, when it's visible again.

Manual unit tests for this logic were also added.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
      - Manual and automated tests added.
      - To be released before friday
      - Release plan: it will be tested immediately after releasing; if there is some problem a simple rollback si needed.
      - Will notify support when it's released.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation.
