### PR TITLE
Fix/chrome 80

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -48,7 +48,7 @@
     "underscore": "~1.8.3",
     "videojs-playlist": "3.1.1",
     "common-header": "https://github.com/Rise-Vision/common-header.git#v4.0.0",
-    "webcomponentsjs": "v1.1.0"
+    "webcomponentsjs": "v0.7.24"
   },
   "resolutions": {
     "angular": "~1.7.0",
@@ -57,6 +57,6 @@
     "font-awesome": "~4.7.0",
     "lodash": "~4.17.4",
     "jquery": "~3.3.1",
-    "webcomponentsjs": "v1.1.0"
+    "webcomponentsjs": "v0.7.24"
   }
 }

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -132,7 +132,7 @@
             init();
           }
 
-          webcomponents.src = config.COMPONENTS_PATH + "webcomponentsjs/webcomponents-loader.js";
+          webcomponents.src = config.COMPONENTS_PATH + "webcomponentsjs/webcomponents.js";
 
           // add the webcomponents polyfill source to the document head
           document.getElementsByTagName( "head" )[ 0 ].appendChild( webcomponents );

--- a/src/widget/storage-file.js
+++ b/src/widget/storage-file.js
@@ -16,9 +16,19 @@ RiseVision.Video.StorageFile = function( data, displayId ) {
    *  Public Methods
    */
   function init() {
-    var storage = document.getElementById( "videoStorage" );
+    var storage = document.getElementById( "videoStorage" ),
+      self = this;
 
     if ( !storage ) {
+      return;
+    }
+
+    if ( !storage.go ) {
+      setTimeout( function() {
+        self.init();
+      }, 100 );
+
+      console.log( "rise-storage component still not initialized; retrying" ); // eslint-disable-line no-console
       return;
     }
 

--- a/src/widget/storage-folder.js
+++ b/src/widget/storage-folder.js
@@ -55,9 +55,19 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
    *  Public Methods
    */
   function init() {
-    var storage = document.getElementById( "videoStorage" );
+    var storage = document.getElementById( "videoStorage" ),
+      self = this;
 
     if ( !storage ) {
+      return;
+    }
+
+    if ( !storage.go ) {
+      setTimeout( function() {
+        self.init();
+      }, 100 );
+
+      console.log( "rise-storage component still not initialized; retrying" ); // eslint-disable-line no-console
       return;
     }
 

--- a/test/integration/js/version.js
+++ b/test/integration/js/version.js
@@ -41,5 +41,5 @@ test( "rise-storage element should be added to body", function() {
 test( "polyfill added to document head", function() {
   var head = document.getElementsByTagName( "head" )[ 0 ];
 
-  assert.isNotNull( head.querySelector( "script[src='" + config.COMPONENTS_PATH + "webcomponentsjs/webcomponents-loader.js'" ) );
+  assert.isNotNull( head.querySelector( "script[src='" + config.COMPONENTS_PATH + "webcomponentsjs/webcomponents.js'" ) );
 } );


### PR DESCRIPTION
## Description
Use v0 of webcomponents polyfill to support the use of HTML Imports and v0 web component features. 

Waiting until the rise-storage `go()` function is available before initializing the instance and setting handlers. Use of _WebComponentsReady_ event does not work reliably, specifically in Preview. 

## Motivation and Context
Chrome 80 deprecation of v0 Web Component features. 

## How Has This Been Tested?
Tested on Chrome 79 & 80 in preview - http://preview.risevision.com/?type=presentation&id=84e5fa62-599f-4029-8a53-555375837dcc

Also tested on current Players with schedule using this presentation - https://apps.risevision.com/editor/workspace/84e5fa62-599f-4029-8a53-555375837dcc?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Will be tested on production after deployment.
  - Rollback requires running previous CCI build of master deployment.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- Notifying Support, documentation
