### PR TITLE
Fix and turn back on integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Rise Vision Video Widget",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "gulp test:unit",
+    "test": "gulp test",
     "build": "gulp build && ./include-deps.sh"
   },
   "repository": {

--- a/test/integration/js/file.js
+++ b/test/integration/js/file.js
@@ -17,11 +17,6 @@ var ready = false,
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  }
-
   check( done );
 } );
 
@@ -244,7 +239,9 @@ suite( "Storage Errors", function() {
         "bubbles": true
       } ) );
 
-      assert( onShowErrorStub.calledWith( "There was a problem retrieving the file." ),
+      console.log(onShowErrorStub.args);
+
+      assert( onShowErrorStub.calledWith( "There was a problem retrieving the file from Rise Cache." ),
         "showError() called with correct message" );
     } else {
       params.event_details = "The request failed with status code: 500";

--- a/test/integration/js/file.js
+++ b/test/integration/js/file.js
@@ -1,4 +1,4 @@
-/* global requests, suiteSetup, suite, suiteTeardown, setup, teardown, test, assert,
+/* global suiteSetup, suite, suiteTeardown, setup, teardown, test, assert,
   RiseVision, sinon, config */
 
 /* eslint-disable func-names */
@@ -238,8 +238,6 @@ suite( "Storage Errors", function() {
         },
         "bubbles": true
       } ) );
-
-      console.log(onShowErrorStub.args);
 
       assert( onShowErrorStub.calledWith( "There was a problem retrieving the file from Rise Cache." ),
         "showError() called with correct message" );

--- a/test/integration/js/folder.js
+++ b/test/integration/js/folder.js
@@ -1,4 +1,4 @@
-/* global requests, suiteSetup, suite, suiteTeardown, setup, teardown, test, assert, RiseVision, sinon, config */
+/* global suiteSetup, suite, suiteTeardown, setup, teardown, test, assert, RiseVision, sinon, config */
 
 /* eslint-disable func-names */
 

--- a/test/integration/js/folder.js
+++ b/test/integration/js/folder.js
@@ -16,11 +16,6 @@ var ready = false,
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  }
-
   check( done );
 } );
 

--- a/test/integration/js/logging-file.js
+++ b/test/integration/js/logging-file.js
@@ -1,4 +1,4 @@
-/* global requests, suiteSetup, suite, teardown, test, assert, RiseVision, sinon */
+/* global suiteSetup, suite, teardown, test, assert, RiseVision, sinon */
 
 /* eslint-disable func-names */
 

--- a/test/integration/js/logging-file.js
+++ b/test/integration/js/logging-file.js
@@ -31,11 +31,6 @@ var spy,
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  }
-
   check( done );
 } );
 

--- a/test/integration/js/logging-folder.js
+++ b/test/integration/js/logging-folder.js
@@ -1,4 +1,4 @@
-/* global requests, suiteSetup, suite, suiteTeardown, teardown, test, assert, RiseVision, sinon */
+/* global suiteSetup, suite, suiteTeardown, teardown, test, assert, RiseVision, sinon */
 
 /* eslint-disable func-names */
 

--- a/test/integration/js/logging-folder.js
+++ b/test/integration/js/logging-folder.js
@@ -34,11 +34,6 @@ var playStub,
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  }
-
   check( done );
 } );
 

--- a/test/integration/js/messaging-file.js
+++ b/test/integration/js/messaging-file.js
@@ -1,4 +1,4 @@
-/* global requests, suiteSetup, suite, test, assert, RiseVision, sinon */
+/* global suiteSetup, suite, test, assert, RiseVision, sinon */
 
 /* eslint-disable func-names */
 

--- a/test/integration/js/messaging-file.js
+++ b/test/integration/js/messaging-file.js
@@ -16,11 +16,6 @@ var ready = false,
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  }
-
   check( done );
 } );
 
@@ -155,7 +150,7 @@ suite( "rise cache error", function() {
         "bubbles": true
       } ) );
 
-      assert.equal( document.querySelector( ".message" ).innerHTML, "There was a problem retrieving the file.", "message text" );
+      assert.equal( document.querySelector( ".message" ).innerHTML, "There was a problem retrieving the file from Rise Cache.", "message text" );
     } else {
       storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
         "detail": {
@@ -177,7 +172,7 @@ suite( "rise cache error", function() {
       storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
         "detail": {
           "error": {
-            "message": "The request failed with status code: 534"
+            "message": "The request failed with status code: 404"
           }
         },
         "bubbles": true

--- a/test/integration/js/messaging-folder.js
+++ b/test/integration/js/messaging-folder.js
@@ -173,7 +173,7 @@ suite( "rise cache error", function() {
       } ) );
 
       assert.equal( document.querySelector( ".message" ).innerHTML,
-        "There was a problem retrieving the file.", "message text" );
+        "There was a problem retrieving the file from Rise Cache.", "message text" );
     } else {
       storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
         "detail": {
@@ -197,7 +197,7 @@ suite( "rise cache error", function() {
       storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
         "detail": {
           "error": {
-            "message": "The request failed with status code: 534"
+            "message": "The request failed with status code: 404"
           }
         },
         "bubbles": true

--- a/test/integration/js/messaging-folder.js
+++ b/test/integration/js/messaging-folder.js
@@ -16,11 +16,6 @@ var ready = false,
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  }
-
   check( done );
 } );
 

--- a/test/integration/js/messaging-folder.js
+++ b/test/integration/js/messaging-folder.js
@@ -1,4 +1,4 @@
-/* global requests, suiteSetup, suiteTeardown, suite, test, assert, RiseVision, sinon */
+/* global suiteSetup, suiteTeardown, suite, test, assert, RiseVision, sinon */
 
 /* eslint-disable func-names */
 

--- a/test/integration/storage-v2/file.html
+++ b/test/integration/storage-v2/file.html
@@ -47,13 +47,6 @@
   isV2Running = true;
 
   sinon.stub(RiseVision.Common.RiseCache, "isV2Running", function (callback) {
-    requests = [];
-    xhr = sinon.useFakeXMLHttpRequest();
-
-    xhr.onCreate = function (xhr) {
-      requests.push(xhr);
-    };
-
     RiseVision.Common.RiseCache.isV2Running.restore();
     RiseVision.Common.RiseCache.isRCV2Player(callback);
   });

--- a/test/integration/storage-v2/folder.html
+++ b/test/integration/storage-v2/folder.html
@@ -47,13 +47,6 @@
   isV2Running = true;
 
   sinon.stub(RiseVision.Common.RiseCache, "isV2Running", function (callback) {
-    requests = [];
-    xhr = sinon.useFakeXMLHttpRequest();
-
-    xhr.onCreate = function (xhr) {
-      requests.push(xhr);
-    };
-
     RiseVision.Common.RiseCache.isV2Running.restore();
     RiseVision.Common.RiseCache.isRCV2Player(callback);
   });

--- a/test/integration/storage-v2/logging-file.html
+++ b/test/integration/storage-v2/logging-file.html
@@ -47,13 +47,6 @@
   isV2Running = true;
 
   sinon.stub(RiseVision.Common.RiseCache, "isV2Running", function (callback) {
-    requests = [];
-    xhr = sinon.useFakeXMLHttpRequest();
-
-    xhr.onCreate = function (xhr) {
-      requests.push(xhr);
-    };
-
     RiseVision.Common.RiseCache.isV2Running.restore();
     RiseVision.Common.RiseCache.isRCV2Player(callback);
   });

--- a/test/integration/storage-v2/logging-folder.html
+++ b/test/integration/storage-v2/logging-folder.html
@@ -47,13 +47,6 @@
   isV2Running = true;
 
   sinon.stub(RiseVision.Common.RiseCache, "isV2Running", function (callback) {
-    requests = [];
-    xhr = sinon.useFakeXMLHttpRequest();
-
-    xhr.onCreate = function (xhr) {
-      requests.push(xhr);
-    };
-
     RiseVision.Common.RiseCache.isV2Running.restore();
     RiseVision.Common.RiseCache.isRCV2Player(callback);
   });

--- a/test/integration/storage-v2/messaging-file.html
+++ b/test/integration/storage-v2/messaging-file.html
@@ -47,13 +47,6 @@
   isV2Running = true;
 
   sinon.stub(RiseVision.Common.RiseCache, "isV2Running", function (callback) {
-    requests = [];
-    xhr = sinon.useFakeXMLHttpRequest();
-
-    xhr.onCreate = function (xhr) {
-      requests.push(xhr);
-    };
-
     RiseVision.Common.RiseCache.isV2Running.restore();
     RiseVision.Common.RiseCache.isRCV2Player(callback);
   });

--- a/test/integration/storage-v2/messaging-folder.html
+++ b/test/integration/storage-v2/messaging-folder.html
@@ -47,13 +47,6 @@
   isV2Running = true;
 
   sinon.stub(RiseVision.Common.RiseCache, "isV2Running", function (callback) {
-    requests = [];
-    xhr = sinon.useFakeXMLHttpRequest();
-
-    xhr.onCreate = function (xhr) {
-      requests.push(xhr);
-    };
-
     RiseVision.Common.RiseCache.isV2Running.restore();
     RiseVision.Common.RiseCache.isRCV2Player(callback);
   });


### PR DESCRIPTION
## Description
Refactored integration tests to omit certain request stubs to fix a timing issue as a result of using polyfill

Re-enabled full test coverage to run

## Motivation and Context
We need integration tests to run when making changes to the Widget to ensure reliability.

## How Has This Been Tested?
Locally and via CCI - https://app.circleci.com/pipelines/github/Rise-Vision/widget-video/10/workflows/eb650b28-4dd3-41f2-b6e9-31c2c2170d59

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
