### PR TITLE
Fix event_details value for a couple endpoint logs

### DIFF
--- a/src/widget/storage-file.js
+++ b/src/widget/storage-file.js
@@ -127,10 +127,10 @@ RiseVision.Video.StorageFile = function( data, displayId ) {
       };
 
       if ( e.detail ) {
-        if ( e.detail.error ) {
+        if ( e.detail.error && e.detail.error.message ) {
           // storage v1
           params.event_details = e.detail.error.message;
-        } else if ( e.detail.resp && e.detail.resp.error ) {
+        } else if ( e.detail.resp && e.detail.resp.error && e.detail.resp.error.message ) {
           // storage v2
           params.event_details = e.detail.resp.error.message;
         }

--- a/src/widget/storage-folder.js
+++ b/src/widget/storage-folder.js
@@ -169,7 +169,7 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
     storage.addEventListener( "rise-cache-error", function( e ) {
       var params = {
         "event": "rise cache error",
-        "event_details": e.detail.error.message
+        "event_details": e.detail.error.message || "no detail"
       };
 
       videoUtils.logEvent( params, { severity: "error", errorCode: "E000000076" } );
@@ -185,10 +185,10 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
       };
 
       if ( e.detail ) {
-        if ( e.detail.error ) {
+        if ( e.detail.error && e.detail.error.message ) {
           // storage v1
           params.event_details = e.detail.error.message;
-        } else if ( e.detail.resp && e.detail.resp.error ) {
+        } else if ( e.detail.resp && e.detail.resp.error && e.detail.resp.error.message ) {
           // storage v2
           params.event_details = e.detail.resp.error.message;
         }


### PR DESCRIPTION
## Description
Ensuring `event_details` value has a true value in a couple specific endpoint logs

## Motivation and Context
Making sure all endpoint logs successfully get inserted

## How Has This Been Tested?
With presentation https://apps.risevision.com/editor/workspace/c65d35db-dca8-4c33-9976-2096c3eddfc8?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f and running in preview (where invalid endpoint logs were caught via console) using Charles to map to locally built version of Widget. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
