### PR TITLE
Support caching files via content sentinel

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,7 @@
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.15.1",
     "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#2.2.1",
     "videojs": "5.11.9",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.13.0",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.13.1",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#v3.5.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
     "underscore": "~1.8.3",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -271,7 +271,7 @@
   });
 
   gulp.task("test", function(cb) {
-    runSequence("version", "es6-modules", "test:unit"/*, "test:integration", "test:e2e"*/, cb);
+    runSequence("version", "es6-modules", "test:unit", "test:integration", "test:e2e", cb);
   });
 
   gulp.task("build", function (cb) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,8 @@
     es6Modules = [
       "./node_modules/common-component/local-messaging.js",
       "./node_modules/common-component/player-local-storage.js",
-      "./node_modules/common-component/player-local-storage-licensing.js"
+      "./node_modules/common-component/player-local-storage-licensing.js",
+      "./node_modules/common-component/rise-content-sentinel.js"
     ];
 
   gulp.task("clean-bower", function(cb){

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -211,17 +211,17 @@
     ]}
   ));
 
-  gulp.task("test:unit:video-rls", factory.testUnitAngular(
+  gulp.task("test:unit:video-watch", factory.testUnitAngular(
     {testFiles: [
       "node_modules/widget-tester/mocks/gadget-mocks.js",
       "src/widget/video-utils.js",
-      "src/widget/video-rls.js",
-      "test/unit/widget/video-rls-spec.js"
+      "src/widget/video-watch.js",
+      "test/unit/widget/video-watch-spec.js"
     ]}
   ));
 
   gulp.task("test:unit:player", function(cb) {
-    runSequence("test:unit:player-utils", "test:unit:player-main", "test:unit:video-rls", cb);
+    runSequence("test:unit:player-utils", "test:unit:player-main", "test:unit:video-watch", cb);
   });
 
   gulp.task("test:unit:widget", factory.testUnitAngular(
@@ -271,7 +271,7 @@
   });
 
   gulp.task("test", function(cb) {
-    runSequence("version", "es6-modules", "test:unit", "test:integration", "test:e2e", cb);
+    runSequence("version", "es6-modules", "test:unit"/*, "test:integration", "test:e2e"*/, cb);
   });
 
   gulp.task("build", function (cb) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2689,7 +2689,7 @@
       "optional": true
     },
     "common-component": {
-      "version": "git://github.com/Rise-Vision/common-component.git#761bdde3948b81a95cb24471ca38346c2d54f8dd",
+      "version": "git://github.com/Rise-Vision/common-component.git#bf5262a1d84a5f9e1e0c4c8e300876096e48e59f",
       "dev": true
     },
     "component-bind": {
@@ -14472,7 +14472,7 @@
       "requires": {
         "async": "0.9.2",
         "casperjs": "1.1.4",
-        "chai": "4.2.0",
+        "chai": "4.3.4",
         "chai-as-promised": "7.1.1",
         "event-stream": "4.0.1",
         "express": "4.17.1",
@@ -14496,7 +14496,7 @@
         "karma-phantomjs-launcher": "1.0.4",
         "karma-sinon-chai": "2.0.2",
         "karma-webpack": "1.8.1",
-        "lodash": "4.17.20",
+        "lodash": "4.17.21",
         "mocha": "6.2.2",
         "mocha-multi": "1.1.3",
         "mocha-proshot": "1.0.1",
@@ -14505,7 +14505,7 @@
         "reporter-file": "0.0.1",
         "run-sequence": "0.3.7",
         "sinon": "7.5.0",
-        "sinon-chai": "3.5.0",
+        "sinon-chai": "3.6.0",
         "spawn-cmd": "0.0.2",
         "spec-xunit-file": "0.0.1-3",
         "xml2js": "0.4.23",
@@ -14567,9 +14567,9 @@
           "dev": true
         },
         "chai": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-          "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+          "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
           "dev": true,
           "requires": {
             "assertion-error": "1.1.0",
@@ -14762,9 +14762,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "log4js": {
@@ -14975,9 +14975,9 @@
           }
         },
         "sinon-chai": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.5.0.tgz",
-          "integrity": "sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.6.0.tgz",
+          "integrity": "sha512-bk2h+0xyKnmvazAnc7HE5esttqmCerSMcBtuB2PS2T4tG6x8woXAxZeJaOJWD+8reXHngnXn0RtIbfEW9OTHFg==",
           "dev": true
         },
         "socket.io": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2689,7 +2689,7 @@
       "optional": true
     },
     "common-component": {
-      "version": "git://github.com/Rise-Vision/common-component.git#bf5262a1d84a5f9e1e0c4c8e300876096e48e59f",
+      "version": "git://github.com/Rise-Vision/common-component.git#b260db08994949c5ec09a84f47849f8809bcd7cb",
       "dev": true
     },
     "component-bind": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bower": "^1.5.3",
     "chai": "^2.1.2",
     "chai-as-promised": "^4.3.0",
-    "common-component": "git://github.com/Rise-Vision/common-component.git#v1.14.1",
+    "common-component": "git://github.com/Rise-Vision/common-component.git#bf5262a1",
     "del": "~1.1.1",
     "eslint": "^3.8.1",
     "eslint-config-idiomatic": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bower": "^1.5.3",
     "chai": "^2.1.2",
     "chai-as-promised": "^4.3.0",
-    "common-component": "git://github.com/Rise-Vision/common-component.git#6b355ce",
+    "common-component": "git://github.com/Rise-Vision/common-component.git#b260db0",
     "del": "~1.1.1",
     "eslint": "^3.8.1",
     "eslint-config-idiomatic": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bower": "^1.5.3",
     "chai": "^2.1.2",
     "chai-as-promised": "^4.3.0",
-    "common-component": "git://github.com/Rise-Vision/common-component.git#bf5262a1",
+    "common-component": "git://github.com/Rise-Vision/common-component.git#6b355ce",
     "del": "~1.1.1",
     "eslint": "^3.8.1",
     "eslint-config-idiomatic": "^2.1.0",

--- a/src/widget.html
+++ b/src/widget.html
@@ -58,6 +58,8 @@
   <script src="components/widget-common/dist/message.js"></script>
   <script src="widget/player-local-storage-file.js"></script>
   <script src="widget/player-local-storage-folder.js"></script>
+  <script src="widget/rise-content-sentinel-file.js"></script>
+  <script src="widget/rise-content-sentinel-folder.js"></script>
   <script src="widget/main.js"></script>
   <script src="widget/analytics.js"></script>
   <!-- endbuild -->

--- a/src/widget.html
+++ b/src/widget.html
@@ -49,7 +49,7 @@
   <script src="config/config.js"></script>
   <script src="widget/video-utils.js"></script>
   <script src="widget/video.js"></script>
-  <script src="widget/video-rls.js"></script>
+  <script src="widget/video-watch.js"></script>
   <script src="widget/player-utils.js"></script>
   <script src="widget/storage-file.js"></script>
   <script src="widget/storage-folder.js"></script>

--- a/src/widget.html
+++ b/src/widget.html
@@ -44,6 +44,7 @@
   <script src="common-modules/local-messaging.js"></script>
   <script src="common-modules/player-local-storage.js"></script>
   <script src="common-modules/player-local-storage-licensing.js"></script>
+  <script src="common-modules/rise-content-sentinel.js"></script>
   <script src="config/version.js"></script>
   <script src="config/config.js"></script>
   <script src="widget/video-utils.js"></script>

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -21,7 +21,7 @@
       if ( playOnceDependenciesAreLoaded ) {
         playOnceDependenciesAreLoaded = false;
 
-        RiseVision.VideoRLS.play();
+        RiseVision.VideoWatch.play();
       }
     }
   }
@@ -87,7 +87,7 @@
       return utils.isServiceWorkerRegistered()
         .then( function() {
           useWatch = true;
-          RiseVision.VideoRLS.setAdditionalParams( additionalParams, mode, displayId, companyId );
+          RiseVision.VideoWatch.setAdditionalParams( additionalParams, mode, displayId, companyId );
         } )
         .catch( function( err ) {
           console.log( err );
@@ -99,7 +99,7 @@
 
     if ( _canUseRLS( mode ) ) {
       useWatch = true;
-      return RiseVision.VideoRLS.setAdditionalParams( additionalParams, mode, displayId, companyId );
+      return RiseVision.VideoWatch.setAdditionalParams( additionalParams, mode, displayId, companyId );
     }
 
     _processStorageNonWatch( additionalParams, mode, displayId )
@@ -189,7 +189,7 @@
       RiseVision.Video.play();
     } else {
       if ( config.STORAGE_ENV === "test" || !isWaitingForScriptDependencies ) {
-        RiseVision.VideoRLS.play();
+        RiseVision.VideoWatch.play();
       } else {
         playOnceDependenciesAreLoaded = true;
       }
@@ -203,7 +203,7 @@
     } else {
       playOnceDependenciesAreLoaded = false;
 
-      RiseVision.VideoRLS.pause();
+      RiseVision.VideoWatch.pause();
     }
 
   }
@@ -214,7 +214,7 @@
     } else {
       playOnceDependenciesAreLoaded = false;
 
-      RiseVision.VideoRLS.stop();
+      RiseVision.VideoWatch.stop();
     }
   }
 

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -83,7 +83,8 @@
       _loadPlaylistPluginScript();
     }
 
-    if ( utils.useContentSentinel() ) {
+    // integration tests will set TEST_USE_SENTINEL to true
+    if ( utils.useContentSentinel() || config.TEST_USE_SENTINEL ) {
       return utils.isServiceWorkerRegistered()
         .then( function() {
           useWatch = true;

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -63,7 +63,7 @@
     document.body.appendChild( script );
   }
 
-  function _isFolder(additionalParams) {
+  function _isFolder( additionalParams ) {
     return !additionalParams.storage.fileName;
   }
 
@@ -77,7 +77,7 @@
   }
 
   function _configureStorageUsage( additionalParams, displayId, companyId ) {
-    var mode = _isFolder( additionalParams ) ? "folder": "file";
+    var mode = _isFolder( additionalParams ) ? "folder" : "file";
 
     if ( mode === "folder" ) {
       _loadPlaylistPluginScript();
@@ -90,7 +90,7 @@
           RiseVision.VideoWatch.setAdditionalParams( additionalParams, mode, displayId, companyId, "sentinel" );
         } )
         .catch( function( err ) {
-          console.log( err );
+          console.log( err ); // eslint-disable-line no-console
 
           /* TODO: Do we send "ready" event to Viewer and on receiving "play" immediately send "done"? Or do we not send "ready" and do nothing?
            */
@@ -105,7 +105,7 @@
     _processStorageNonWatch( additionalParams, mode, displayId )
   }
 
-  function _processStorageNonWatch(additionalParams, mode, displayId) {
+  function _processStorageNonWatch( additionalParams, mode, displayId ) {
     // check which version of Rise Cache is running and dynamically add rise-storage dependencies
     RiseVision.Common.RiseCache.isRCV2Player( function( isV2 ) {
       var fragment = document.createDocumentFragment(),

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -4,9 +4,10 @@
   "use strict";
 
   var id = new gadgets.Prefs().getString( "id" ),
+    utils = RiseVision.Common.Utilities,
     isWaitingForScriptDependencies = false,
     playOnceDependenciesAreLoaded = false,
-    useRLS = false;
+    useWatch = false;
 
   // Disable context menu (right click menu)
   window.oncontextmenu = function() {
@@ -49,7 +50,6 @@
     return false;
   }
 
-
   function _loadPlaylistPluginScript() {
     var src = config.COMPONENTS_PATH + "videojs-playlist/dist/videojs-playlist.min.js",
       script = document.createElement( "script" );
@@ -63,9 +63,94 @@
     document.body.appendChild( script );
   }
 
+  function _isFolder(additionalParams) {
+    return !additionalParams.storage.fileName;
+  }
+
+  function _canUseRLS( mode ) {
+    // integration tests will set TEST_USE_RLS to true
+    if ( mode === "folder" ) {
+      return config.TEST_USE_RLS || canUseRLSFolder();
+    }
+
+    return config.TEST_USE_RLS || canUseRLSSingleFile();
+  }
+
+  function _configureStorageUsage( additionalParams, displayId, companyId ) {
+    var mode = _isFolder( additionalParams ) ? "folder": "file";
+
+    if ( mode === "folder" ) {
+      _loadPlaylistPluginScript();
+    }
+
+    if ( utils.useContentSentinel() ) {
+      return utils.isServiceWorkerRegistered()
+        .then( function() {
+          useWatch = true;
+          RiseVision.VideoRLS.setAdditionalParams( additionalParams, mode, displayId, companyId );
+        } )
+        .catch( function( err ) {
+          console.log( err );
+
+          /* TODO: Do we send "ready" event to Viewer and on receiving "play" immediately send "done"? Or do we not send "ready" and do nothing?
+           */
+        } );
+    }
+
+    if ( _canUseRLS( mode ) ) {
+      useWatch = true;
+      return RiseVision.VideoRLS.setAdditionalParams( additionalParams, mode, displayId, companyId );
+    }
+
+    _processStorageNonWatch( additionalParams, mode, displayId )
+  }
+
+  function _processStorageNonWatch(additionalParams, mode, displayId) {
+    // check which version of Rise Cache is running and dynamically add rise-storage dependencies
+    RiseVision.Common.RiseCache.isRCV2Player( function( isV2 ) {
+      var fragment = document.createDocumentFragment(),
+        link = document.createElement( "link" ),
+        webcomponents = document.createElement( "script" ),
+        href = config.COMPONENTS_PATH + ( ( isV2 ) ? "rise-storage-v2" : "rise-storage" ) + "/rise-storage.html",
+        storage = document.createElement( "rise-storage" );
+
+      function init() {
+        RiseVision.Video.setAdditionalParams( additionalParams, mode, displayId );
+      }
+
+      function onStorageReady() {
+        storage.removeEventListener( "rise-storage-ready", onStorageReady );
+        init();
+      }
+
+      webcomponents.src = config.COMPONENTS_PATH + "webcomponentsjs/webcomponents.js";
+
+      // add the webcomponents polyfill source to the document head
+      document.getElementsByTagName( "head" )[ 0 ].appendChild( webcomponents );
+
+      link.setAttribute( "rel", "import" );
+      link.setAttribute( "href", href );
+
+      // add the rise-storage <link> element to document head
+      document.getElementsByTagName( "head" )[ 0 ].appendChild( link );
+
+      storage.setAttribute( "id", "videoStorage" );
+      storage.setAttribute( "refresh", 5 );
+
+      if ( isV2 ) {
+        storage.setAttribute( "usage", "widget" );
+      }
+
+      storage.addEventListener( "rise-storage-ready", onStorageReady );
+      fragment.appendChild( storage );
+
+      // add the <rise-storage> element to the body
+      document.body.appendChild( fragment );
+    } );
+  }
+
   function configure( names, values ) {
     var additionalParams = null,
-      mode = "",
       companyId = "",
       displayId = "";
 
@@ -90,79 +175,17 @@
         additionalParams = JSON.parse( values[ 2 ] );
 
         if ( Object.keys( additionalParams.storage ).length !== 0 ) {
-          // storage file or folder selected
-          if ( !additionalParams.storage.fileName ) {
-            // folder was selected
-            mode = "folder";
-            _loadPlaylistPluginScript();
-
-            // TODO: trigger test coverage for RLS with folder
-            useRLS = config.TEST_USE_RLS || canUseRLSFolder();
-          } else {
-            // file was selected
-            mode = "file";
-
-            // integration tests will set TEST_USE_RLS to true
-            useRLS = config.TEST_USE_RLS || canUseRLSSingleFile();
-          }
+          _configureStorageUsage( additionalParams, displayId, companyId );
         } else {
           // non-storage file was selected
-          mode = "file";
+          RiseVision.Video.setAdditionalParams( additionalParams, "file", displayId );
         }
-
-        if ( useRLS ) {
-          // proceed with using RLS for single file
-          RiseVision.VideoRLS.setAdditionalParams( additionalParams, mode, displayId, companyId );
-          return;
-        }
-
-        // check which version of Rise Cache is running and dynamically add rise-storage dependencies
-        RiseVision.Common.RiseCache.isRCV2Player( function( isV2 ) {
-          var fragment = document.createDocumentFragment(),
-            link = document.createElement( "link" ),
-            webcomponents = document.createElement( "script" ),
-            href = config.COMPONENTS_PATH + ( ( isV2 ) ? "rise-storage-v2" : "rise-storage" ) + "/rise-storage.html",
-            storage = document.createElement( "rise-storage" );
-
-          function init() {
-            RiseVision.Video.setAdditionalParams( additionalParams, mode, displayId );
-          }
-
-          function onStorageReady() {
-            storage.removeEventListener( "rise-storage-ready", onStorageReady );
-            init();
-          }
-
-          webcomponents.src = config.COMPONENTS_PATH + "webcomponentsjs/webcomponents.js";
-
-          // add the webcomponents polyfill source to the document head
-          document.getElementsByTagName( "head" )[ 0 ].appendChild( webcomponents );
-
-          link.setAttribute( "rel", "import" );
-          link.setAttribute( "href", href );
-
-          // add the rise-storage <link> element to document head
-          document.getElementsByTagName( "head" )[ 0 ].appendChild( link );
-
-          storage.setAttribute( "id", "videoStorage" );
-          storage.setAttribute( "refresh", 5 );
-
-          if ( isV2 ) {
-            storage.setAttribute( "usage", "widget" );
-          }
-
-          storage.addEventListener( "rise-storage-ready", onStorageReady );
-          fragment.appendChild( storage );
-
-          // add the <rise-storage> element to the body
-          document.body.appendChild( fragment );
-        } );
       }
     }
   }
 
   function play() {
-    if ( !useRLS ) {
+    if ( !useWatch ) {
       RiseVision.Video.play();
     } else {
       if ( config.STORAGE_ENV === "test" || !isWaitingForScriptDependencies ) {
@@ -175,7 +198,7 @@
   }
 
   function pause() {
-    if ( !useRLS ) {
+    if ( !useWatch ) {
       RiseVision.Video.pause();
     } else {
       playOnceDependenciesAreLoaded = false;
@@ -186,7 +209,7 @@
   }
 
   function stop() {
-    if ( !useRLS ) {
+    if ( !useWatch ) {
       RiseVision.Video.stop();
     } else {
       playOnceDependenciesAreLoaded = false;

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -87,7 +87,7 @@
       return utils.isServiceWorkerRegistered()
         .then( function() {
           useWatch = true;
-          RiseVision.VideoWatch.setAdditionalParams( additionalParams, mode, displayId, companyId );
+          RiseVision.VideoWatch.setAdditionalParams( additionalParams, mode, displayId, companyId, "sentinel" );
         } )
         .catch( function( err ) {
           console.log( err );
@@ -99,7 +99,7 @@
 
     if ( _canUseRLS( mode ) ) {
       useWatch = true;
-      return RiseVision.VideoWatch.setAdditionalParams( additionalParams, mode, displayId, companyId );
+      return RiseVision.VideoWatch.setAdditionalParams( additionalParams, mode, displayId, companyId, "rls" );
     }
 
     _processStorageNonWatch( additionalParams, mode, displayId )

--- a/src/widget/player-local-storage-file.js
+++ b/src/widget/player-local-storage-file.js
@@ -3,9 +3,9 @@
 
 var RiseVision = RiseVision || {};
 
-RiseVision.VideoRLS = RiseVision.VideoRLS || {};
+RiseVision.VideoWatch = RiseVision.VideoWatch || {};
 
-RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
+RiseVision.VideoWatch.PlayerLocalStorageFile = function() {
   "use strict";
 
   var INITIAL_PROCESSING_DELAY = 10000,
@@ -27,7 +27,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
   function _startInitialProcessingTimer() {
     initialProcessingTimer = setTimeout( function() {
       // file is still processing/downloading
-      RiseVision.VideoRLS.onFileUnavailable( "File is downloading." );
+      RiseVision.VideoWatch.onFileUnavailable( "File is downloading." );
     }, INITIAL_PROCESSING_DELAY );
   }
 
@@ -42,7 +42,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       "file_url": filePath
     }, { severity: "error", errorCode: "E000000025", debugInfo: JSON.stringify( { file_url: filePath } ) } );
 
-    RiseVision.VideoRLS.handleError();
+    RiseVision.VideoWatch.handleError();
   }
 
   function _handleRequiredModulesUnavailable() {
@@ -52,7 +52,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       "file_url": filePath
     }, { severity: "error", errorCode: "E000000025", debugInfo: JSON.stringify( { file_url: filePath } ) } );
 
-    RiseVision.VideoRLS.handleError();
+    RiseVision.VideoWatch.handleError();
   }
 
   function _handleUnauthorized() {
@@ -62,7 +62,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       "file_url": filePath
     }, { severity: "error", errorCode: "E000000016", debugInfo: JSON.stringify( { file_url: filePath } ) } );
 
-    RiseVision.VideoRLS.handleError();
+    RiseVision.VideoWatch.handleError();
   }
 
   function _handleAuthorized() {
@@ -98,7 +98,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
     if ( initialLoad ) {
       initialLoad = false;
 
-      RiseVision.VideoRLS.onFileInit( {
+      RiseVision.VideoWatch.onFileInit( {
         filePath: filePath,
         url: data.fileUrl,
         name: videoUtils.getStorageFileName( filePath )
@@ -107,7 +107,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       return;
     }
 
-    RiseVision.VideoRLS.onFileRefresh( {
+    RiseVision.VideoWatch.onFileRefresh( {
       filePath: filePath,
       url: data.fileUrl,
       name: videoUtils.getStorageFileName( filePath )
@@ -123,7 +123,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
 
     videoUtils.logEvent( params, { severity: "error", errorCode: "E000000014", debugInfo: JSON.stringify( { file_url: params.file_url } ) } );
 
-    RiseVision.VideoRLS.handleError();
+    RiseVision.VideoWatch.handleError();
   }
 
   function _handleFileDeleted( data ) {
@@ -133,7 +133,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
       "file_url": data.filePath
     }, { severity: "info", debugInfo: JSON.stringify( { file_url: data.filePath } ) } );
 
-    RiseVision.VideoRLS.onFileDeleted( data.filePath );
+    RiseVision.VideoWatch.onFileDeleted( data.filePath );
   }
 
   function _handleFileError( data ) {
@@ -167,7 +167,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFile = function() {
      */
 
     // Widget will display generic message
-    RiseVision.VideoRLS.handleError();
+    RiseVision.VideoWatch.handleError();
   }
 
   function _handleEvents( data ) {

--- a/src/widget/player-local-storage-folder.js
+++ b/src/widget/player-local-storage-folder.js
@@ -3,9 +3,9 @@
 
 var RiseVision = RiseVision || {};
 
-RiseVision.VideoRLS = RiseVision.VideoRLS || {};
+RiseVision.VideoWatch = RiseVision.VideoWatch || {};
 
-RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
+RiseVision.VideoWatch.PlayerLocalStorageFolder = function() {
   "use strict";
 
   var INITIAL_PROCESSING_DELAY = 15000,
@@ -108,9 +108,9 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
         "file_format": "unknown"
       }, { severity: "error", errorCode: "E000000021", debugInfo: JSON.stringify( { file_url: folderPath, file_format: "unknown" } ) } );
 
-      RiseVision.VideoRLS.onFolderFilesRemoved();
+      RiseVision.VideoWatch.onFolderFilesRemoved();
     } else {
-      RiseVision.VideoRLS.onFileRefresh( files );
+      RiseVision.VideoWatch.onFileRefresh( files );
     }
   }
 
@@ -134,17 +134,17 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
             "file_format": "unknown"
           }, { severity: "warning", debugInfo: JSON.stringify( { file_url: folderPath, file_format: "unknown" } ) } );
 
-          RiseVision.VideoRLS.handleError();
+          RiseVision.VideoWatch.handleError();
           return;
         }
 
         // files are still processing/downloading
-        RiseVision.VideoRLS.onFileUnavailable( "Files are downloading." );
+        RiseVision.VideoWatch.onFileUnavailable( "Files are downloading." );
         return;
       }
 
       initialLoad = false;
-      RiseVision.VideoRLS.onFileInit( files );
+      RiseVision.VideoWatch.onFileInit( files );
     }, INITIAL_PROCESSING_DELAY );
   }
 
@@ -156,7 +156,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
       "file_format": defaultFileFormat
     }, { severity: "error", errorCode: "E000000025", debugInfo: JSON.stringify( { file_url: folderPath, file_format: defaultFileFormat } ) } );
 
-    RiseVision.VideoRLS.handleError();
+    RiseVision.VideoWatch.handleError();
   }
 
   function _handleRequiredModulesUnavailable() {
@@ -167,7 +167,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
       "file_format": defaultFileFormat
     }, { severity: "error", errorCode: "E000000025", debugInfo: JSON.stringify( { file_url: folderPath, file_format: defaultFileFormat } ) } );
 
-    RiseVision.VideoRLS.handleError();
+    RiseVision.VideoWatch.handleError();
   }
 
   function _handleUnauthorized() {
@@ -178,7 +178,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
       "file_format": defaultFileFormat
     }, { severity: "error", errorCode: "E000000016", debugInfo: JSON.stringify( { file_url: folderPath, file_format: defaultFileFormat } ) } );
 
-    RiseVision.VideoRLS.handleError();
+    RiseVision.VideoWatch.handleError();
   }
 
   function _handleAuthorized() {
@@ -214,7 +214,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
       _clearInitialProcessingTimer();
       initialLoad = false;
 
-      RiseVision.VideoRLS.onFileInit( files );
+      RiseVision.VideoWatch.onFileInit( files );
     }
 
     if ( initialLoad ) {
@@ -232,7 +232,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
       return;
     }
 
-    RiseVision.VideoRLS.onFileRefresh( files );
+    RiseVision.VideoWatch.onFileRefresh( files );
   }
 
   function _handleFolderNoExist() {
@@ -245,7 +245,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
 
     videoUtils.logEvent( params, { severity: "error", errorCode: "E000000022", debugInfo: JSON.stringify( { file_url: folderPath, file_format: defaultFileFormat } ) } );
 
-    RiseVision.VideoRLS.onFolderUnavailable();
+    RiseVision.VideoWatch.onFolderUnavailable();
   }
 
   function _handleFolderEmpty() {
@@ -258,7 +258,7 @@ RiseVision.VideoRLS.PlayerLocalStorageFolder = function() {
 
     videoUtils.logEvent( params, { severity: "error", errorCode: "E000000021", debugInfo: JSON.stringify( { file_url: folderPath, file_format: defaultFileFormat } ) } );
 
-    RiseVision.VideoRLS.onFolderUnavailable();
+    RiseVision.VideoWatch.onFolderUnavailable();
   }
 
   function _handleFileDeleted( data ) {

--- a/src/widget/player-vjs.js
+++ b/src/widget/player-vjs.js
@@ -41,7 +41,7 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     var filePath = "",
       i;
 
-    if ( _videoUtils.getUsingRLS() && _files && _files.length && _files.length > 0 ) {
+    if ( _videoUtils.getUsingWatch() && _files && _files.length && _files.length > 0 ) {
       for ( i = 0; i < _files.length; i++ ) {
         if ( _files[ i ].url === url ) {
           filePath = _files[ i ].filePath;
@@ -158,7 +158,7 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
   }
 
   function _initPlaylist() {
-    var usingRLS = _videoUtils.getUsingRLS(),
+    var usingWatch = _videoUtils.getUsingWatch(),
       playlist = [],
       playlistItem,
       sources,
@@ -167,8 +167,8 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
     _files.forEach( function addPlaylistItem( file ) {
       sources = [];
       source = {
-        src: usingRLS ? file.url : file,
-        type: _utils.getVideoFileType( ( usingRLS ? file.name : file ) )
+        src: usingWatch ? file.url : file,
+        type: _utils.getVideoFileType( ( usingWatch ? file.name : file ) )
       };
 
       sources.push( source );
@@ -219,14 +219,14 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
   }
 
   function _ready() {
-    var usingRLS = _videoUtils.getUsingRLS(),
+    var usingWatch = _videoUtils.getUsingWatch(),
       fileType,
       fileURl;
 
     if ( _files && _files.length && _files.length > 0 ) {
       if ( mode === "file" ) {
-        fileType = _utils.getVideoFileType( ( usingRLS ? _files[ 0 ].name : _files[ 0 ] ) );
-        fileURl = usingRLS ? _files[ 0 ].url : _files[ 0 ];
+        fileType = _utils.getVideoFileType( ( usingWatch ? _files[ 0 ].name : _files[ 0 ] ) );
+        fileURl = usingWatch ? _files[ 0 ].url : _files[ 0 ];
 
         _playerInstance.src( { type: fileType, src: fileURl } );
       } else if ( mode === "folder" ) {
@@ -294,7 +294,7 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
   }
 
   function play() {
-    var usingRLS = _videoUtils.getUsingRLS(),
+    var usingWatch = _videoUtils.getUsingWatch(),
       fileType,
       fileURl;
 
@@ -306,8 +306,8 @@ RiseVision.PlayerVJS = function PlayerVJS( params, mode, videoRef ) {
       // set a new source
       if ( _files && _files.length && _files.length > 0 ) {
         if ( mode === "file" ) {
-          fileType = _utils.getVideoFileType( ( usingRLS ? _files[ 0 ].name : _files[ 0 ] ) );
-          fileURl = usingRLS ? _files[ 0 ].url : _files[ 0 ];
+          fileType = _utils.getVideoFileType( ( usingWatch ? _files[ 0 ].name : _files[ 0 ] ) );
+          fileURl = usingWatch ? _files[ 0 ].url : _files[ 0 ];
 
           _playerInstance.src( { type: fileType, src: fileURl } );
         } else if ( mode === "folder" ) {

--- a/src/widget/rise-content-sentinel-file.js
+++ b/src/widget/rise-content-sentinel-file.js
@@ -1,4 +1,4 @@
-/* global riseContentSentinel, config, _ */
+/* global riseContentSentinel, _ */
 /* eslint-disable no-console */
 
 var RiseVision = RiseVision || {};
@@ -111,21 +111,21 @@ RiseVision.VideoWatch.RiseContentSentinelFile = function() {
     }
 
     switch ( data.event.toUpperCase() ) {
-      case "FILE-AVAILABLE":
-        _handleFileAvailable( data );
-        break;
-      case "FILE-PROCESSING":
-        _handleFileProcessing();
-        break;
-      case "FILE-NO-EXIST":
-        _handleFileNoExist( data );
-        break;
-      case "FILE-DELETED":
-        _handleFileDeleted( data );
-        break;
-      case "FILE-ERROR":
-        _handleFileError( data );
-        break;
+    case "FILE-AVAILABLE":
+      _handleFileAvailable( data );
+      break;
+    case "FILE-PROCESSING":
+      _handleFileProcessing();
+      break;
+    case "FILE-NO-EXIST":
+      _handleFileNoExist( data );
+      break;
+    case "FILE-DELETED":
+      _handleFileDeleted( data );
+      break;
+    case "FILE-ERROR":
+      _handleFileError( data );
+      break;
     }
   }
 

--- a/src/widget/rise-content-sentinel-file.js
+++ b/src/widget/rise-content-sentinel-file.js
@@ -1,0 +1,148 @@
+/* global riseContentSentinel, config, _ */
+/* eslint-disable no-console */
+
+var RiseVision = RiseVision || {};
+
+RiseVision.VideoWatch = RiseVision.VideoWatch || {};
+
+RiseVision.VideoWatch.RiseContentSentinelFile = function() {
+  "use strict";
+
+  var INITIAL_PROCESSING_DELAY = 10000,
+    videoUtils = RiseVision.VideoUtils,
+    filePath = "",
+    contentSentinel = null,
+    initialProcessingTimer = null,
+    initialLoad = true,
+    fileErrorLogParams = null;
+
+  function _clearInitialProcessingTimer() {
+    clearTimeout( initialProcessingTimer );
+    initialProcessingTimer = null;
+  }
+
+  function _startInitialProcessingTimer() {
+    initialProcessingTimer = setTimeout( function() {
+      // file is still processing/downloading
+      RiseVision.VideoWatch.onFileUnavailable( "File is downloading." );
+    }, INITIAL_PROCESSING_DELAY );
+  }
+
+  function _resetFileErrorLogParams() {
+    fileErrorLogParams = null;
+  }
+
+  function _handleFileProcessing() {
+    _resetFileErrorLogParams();
+
+    if ( initialLoad && !initialProcessingTimer ) {
+      _startInitialProcessingTimer();
+    }
+  }
+
+  function _handleFileAvailable( data ) {
+    _clearInitialProcessingTimer();
+    _resetFileErrorLogParams();
+
+    if ( initialLoad ) {
+      initialLoad = false;
+
+      RiseVision.VideoWatch.onFileInit( {
+        filePath: filePath,
+        url: data.fileUrl,
+        name: videoUtils.getStorageFileName( filePath )
+      } );
+
+      return;
+    }
+
+    RiseVision.VideoWatch.onFileRefresh( {
+      filePath: filePath,
+      url: data.fileUrl,
+      name: videoUtils.getStorageFileName( filePath )
+    } );
+  }
+
+  function _handleFileNoExist( data ) {
+    var params = {
+      "event": "error",
+      "event_details": "file does not exist",
+      "file_url": data.filePath
+    };
+
+    videoUtils.logEvent( params, { severity: "error", errorCode: "E000000014", debugInfo: JSON.stringify( { file_url: params.file_url } ) } );
+
+    RiseVision.VideoWatch.handleError();
+  }
+
+  function _handleFileDeleted( data ) {
+    videoUtils.logEvent( {
+      "event": "info",
+      "event_details": "file deleted",
+      "file_url": data.filePath
+    }, { severity: "info", debugInfo: JSON.stringify( { file_url: data.filePath } ) } );
+
+    RiseVision.VideoWatch.onFileDeleted( data.filePath );
+  }
+
+  function _handleFileError( data ) {
+    var msg = data.msg || "",
+      detail = data.detail || "",
+      params = {
+        "event": "error",
+        "event_details": msg + ( detail ? " | " + detail : "" ),
+        "file_url": data.filePath
+      };
+
+    // prevent repetitive logging when widget is receiving messages from other potential widget instances watching same file
+    if ( _.isEqual( params, fileErrorLogParams ) ) {
+      return;
+    }
+
+    fileErrorLogParams = _.clone( params );
+    videoUtils.logEvent( params, { severity: "error", errorCode: "E000000027", debugInfo: JSON.stringify( { file_url: params.file_url } ) } );
+
+    RiseVision.VideoWatch.handleError();
+  }
+
+  function _handleEvents( data ) {
+    if ( !data || !data.event || typeof data.event !== "string" ) {
+      return;
+    }
+
+    switch ( data.event.toUpperCase() ) {
+      case "FILE-AVAILABLE":
+        _handleFileAvailable( data );
+        break;
+      case "FILE-PROCESSING":
+        _handleFileProcessing();
+        break;
+      case "FILE-NO-EXIST":
+        _handleFileNoExist( data );
+        break;
+      case "FILE-DELETED":
+        _handleFileDeleted( data );
+        break;
+      case "FILE-ERROR":
+        _handleFileError( data );
+        break;
+    }
+  }
+
+  function init() {
+    filePath = videoUtils.getStorageSingleFilePath();
+    contentSentinel = new riseContentSentinel.default( _handleEvents );
+
+    // start watching the file
+    contentSentinel.watchFiles( filePath );
+  }
+
+  function retry() {
+    _handleFileProcessing();
+  }
+
+  return {
+    "init": init,
+    "retry": retry
+  };
+};

--- a/src/widget/rise-content-sentinel-folder.js
+++ b/src/widget/rise-content-sentinel-folder.js
@@ -245,19 +245,6 @@ RiseVision.VideoWatch.RiseContentSentinelFolder = function() {
       params: _.clone( params )
     } );
 
-    /*** Possible error messages from Local Storage ***/
-    /*
-      "File's host server could not be reached"
-
-      "File I/O Error"
-
-      "Could not retrieve signed URL"
-
-      "Insufficient disk space"
-
-      "Invalid response with status code [CODE]"
-     */
-
     videoUtils.logEvent( params, { severity: "error", errorCode: "E000000027", debugInfo: JSON.stringify( { file_url: params.file_url } ) } );
 
     if ( !initialLoad && !initialProcessingTimer ) {

--- a/src/widget/rise-content-sentinel-folder.js
+++ b/src/widget/rise-content-sentinel-folder.js
@@ -1,0 +1,332 @@
+/* global riseContentSentinel, config _ */
+/* eslint-disable no-console */
+
+var RiseVision = RiseVision || {};
+
+RiseVision.VideoWatch = RiseVision.VideoWatch || {};
+
+RiseVision.VideoWatch.RiseContentSentinelFolder = function() {
+  "use strict";
+
+  var INITIAL_PROCESSING_DELAY = 15000,
+    videoUtils = RiseVision.VideoUtils,
+    defaultFileFormat = "unknown",
+    folderPath = "",
+    contentSentinel = null,
+    files = [],
+    filesInError = [],
+    initialProcessingTimer = null,
+    initialLoad = true;
+
+  function _getFileInError( filePath ) {
+    return _.find( filesInError, function( file ) {
+      return file.filePath === filePath;
+    } );
+  }
+
+  function _getFile( filePath ) {
+    return _.find( files, function( file ) {
+      return file.filePath === filePath;
+    } );
+  }
+
+  function _manageFileInError( data, fixed ) {
+    var filePath = data.filePath,
+      fileInError = _.find( filesInError, function( file ) {
+        return file.filePath === filePath;
+      } );
+
+    if ( !filePath ) {
+      return;
+    }
+
+    if ( fixed && fileInError ) {
+      // remove this file from files in error list
+      filesInError = _.reject( filesInError, function( file ) {
+        return file.filePath === filePath;
+      } );
+    } else if ( !fixed ) {
+      if ( !fileInError ) {
+        fileInError = {
+          filePath: filePath,
+          params: data.params
+        };
+        // add this file to list of files in error
+        filesInError.push( fileInError );
+      } else {
+        fileInError.params = _.clone( data.params );
+      }
+    }
+  }
+
+  function _manageFile( data, state ) {
+    var filePath = data.filePath,
+      fileUrl = data.fileUrl,
+      managedFile = _.find( files, function( file ) {
+        return file.filePath === filePath;
+      } );
+
+    if ( state.toUpperCase() === "AVAILABLE" ) {
+      if ( !managedFile ) {
+        managedFile = {
+          filePath: filePath,
+          url: fileUrl,
+          name: videoUtils.getStorageFileName( filePath )
+        };
+
+        // add this file to list
+        files.push( managedFile );
+      } else {
+        // file has been updated
+        managedFile.url = fileUrl
+      }
+    }
+
+    if ( state.toUpperCase() === "DELETED" ) {
+      if ( managedFile ) {
+        files = _.reject( files, function( file ) {
+          return file.filePath === filePath;
+        } );
+      }
+    }
+
+    files = _.sortBy( files, function( file ) {
+      return file.name.toLowerCase();
+    } );
+  }
+
+  function _onFileRemoved() {
+    if ( files.length < 1 ) {
+      // No files to show anymore, log and display a message
+      videoUtils.logEvent( {
+        "event": "error",
+        "event_details": "No files to display",
+        "file_url": folderPath,
+        "file_format": "unknown"
+      }, { severity: "error", errorCode: "E000000021", debugInfo: JSON.stringify( { file_url: folderPath, file_format: "unknown" } ) } );
+
+      RiseVision.VideoWatch.onFolderFilesRemoved();
+    } else {
+      RiseVision.VideoWatch.onFileRefresh( files );
+    }
+  }
+
+  function _clearInitialProcessingTimer() {
+    clearTimeout( initialProcessingTimer );
+    initialProcessingTimer = null;
+  }
+
+  function _startInitialProcessingTimer() {
+    initialProcessingTimer = setTimeout( function() {
+      // explicitly set to null for integration test purposes
+      initialProcessingTimer = null;
+
+      if ( files.length < 1 ) {
+        if ( filesInError.length > 0 ) {
+          // Some files during initial processing had a file error and no files became available
+          videoUtils.logEvent( {
+            "event": "warning",
+            "event_details": "No files to display (startup)",
+            "file_url": folderPath,
+            "file_format": "unknown"
+          }, { severity: "warning", debugInfo: JSON.stringify( { file_url: folderPath, file_format: "unknown" } ) } );
+
+          RiseVision.VideoWatch.handleError();
+          return;
+        }
+
+        // files are still processing/downloading
+        RiseVision.VideoWatch.onFileUnavailable( "Files are downloading." );
+        return;
+      }
+
+      initialLoad = false;
+      RiseVision.VideoWatch.onFileInit( files );
+    }, INITIAL_PROCESSING_DELAY );
+  }
+
+  function _handleFileProcessing() {
+    if ( initialLoad && !initialProcessingTimer ) {
+      _startInitialProcessingTimer();
+    }
+  }
+
+  function _handleFileAvailable( data ) {
+    _manageFile( data, "available" );
+    _manageFileInError( data, true );
+
+    function ready() {
+      _clearInitialProcessingTimer();
+      initialLoad = false;
+
+      RiseVision.VideoWatch.onFileInit( files );
+    }
+
+    if ( initialLoad ) {
+      if ( files.length > 1 ) {
+        ready();
+      } else if ( files.length === 1 ) {
+        // delay 2 seconds to allow for potentially one more file that's available
+        setTimeout( function() {
+          if ( files.length === 1 && initialLoad ) {
+            ready();
+          }
+        }, 2000 );
+      }
+
+      return;
+    }
+
+    RiseVision.VideoWatch.onFileRefresh( files );
+  }
+
+  function _handleFolderNoExist() {
+    var params = {
+      "event": "error",
+      "event_details": "folder does not exist",
+      "file_url": folderPath,
+      "file_format": defaultFileFormat
+    };
+
+    videoUtils.logEvent( params, { severity: "error", errorCode: "E000000022", debugInfo: JSON.stringify( { file_url: folderPath, file_format: defaultFileFormat } ) } );
+
+    RiseVision.VideoWatch.onFolderUnavailable();
+  }
+
+  function _handleFolderEmpty() {
+    var params = {
+      "event": "error",
+      "event_details": "folder empty",
+      "file_url": folderPath,
+      "file_format": defaultFileFormat
+    };
+
+    videoUtils.logEvent( params, { severity: "error", errorCode: "E000000021", debugInfo: JSON.stringify( { file_url: folderPath, file_format: defaultFileFormat } ) } );
+
+    RiseVision.VideoWatch.onFolderUnavailable();
+  }
+
+  function _handleFileDeleted( data ) {
+    var file = _getFile( data.filePath ),
+      params = {
+        "event": "info",
+        "event_details": "file deleted",
+        "file_url": data.filePath,
+        "local_url": ( file && file.url ) ? file.url : ""
+      };
+
+    _manageFile( data, "deleted" );
+    _manageFileInError( data, true );
+
+    videoUtils.logEvent( params, { severity: "info", debugInfo: JSON.stringify( { file_url: params.file_url, local_url: params.local_url } ) } );
+
+    if ( !initialLoad && !initialProcessingTimer ) {
+      _onFileRemoved();
+    }
+  }
+
+  function _handleFileError( data ) {
+    var msg = data.msg || "",
+      detail = data.detail || "",
+      params = {
+        "event": "error",
+        "event_details": msg + ( detail ? " | " + detail : "" ),
+        "file_url": data.filePath
+      },
+      fileInError = _getFileInError( data.filePath );
+
+    // prevent repetitive logging when widget is receiving messages from other potential widget instances watching same file
+    if ( fileInError && _.isEqual( params, fileInError.params ) ) {
+      return;
+    }
+
+    _manageFileInError( {
+      filePath: data.filePath,
+      params: _.clone( params )
+    } );
+
+    /*** Possible error messages from Local Storage ***/
+    /*
+      "File's host server could not be reached"
+
+      "File I/O Error"
+
+      "Could not retrieve signed URL"
+
+      "Insufficient disk space"
+
+      "Invalid response with status code [CODE]"
+     */
+
+    videoUtils.logEvent( params, { severity: "error", errorCode: "E000000027", debugInfo: JSON.stringify( { file_url: params.file_url } ) } );
+
+    if ( !initialLoad && !initialProcessingTimer ) {
+      if ( _getFile( data.filePath ) ) {
+        // remove this file from the file list since there was a problem with its new version being provided
+        _manageFile( { filePath: data.filePath }, "deleted" );
+        _onFileRemoved();
+      }
+    }
+  }
+
+  function _handleEvents( data ) {
+    if ( !data || !data.event || typeof data.event !== "string" ) {
+      return;
+    }
+
+    switch ( data.event.toUpperCase() ) {
+      case "NO-CONNECTION":
+        _handleNoConnection();
+        break;
+      case "REQUIRED-MODULES-UNAVAILABLE":
+        _handleRequiredModulesUnavailable();
+        break;
+      case "AUTHORIZED":
+        _handleAuthorized();
+        break;
+      case "UNAUTHORIZED":
+        _handleUnauthorized();
+        break;
+      case "AUTHORIZATION-ERROR":
+        _handleAuthorizationError;
+        break;
+      case "FILE-AVAILABLE":
+        _handleFileAvailable( data );
+        break;
+      case "FILE-PROCESSING":
+        _handleFileProcessing();
+        break;
+      case "FOLDER-NO-EXIST":
+        _handleFolderNoExist();
+        break;
+      case "FOLDER-EMPTY":
+        _handleFolderEmpty();
+        break;
+      case "FILE-DELETED":
+        _handleFileDeleted( data );
+        break;
+      case "FILE-ERROR":
+        _handleFileError( data );
+        break;
+    }
+  }
+
+  function init() {
+    folderPath = videoUtils.getStorageFolderPath();
+    contentSentinel = new riseContentSentinel.default( _handleEvents );
+
+    // start watching the folder
+    contentSentinel.watchFiles( folderPath, "video" );
+  }
+
+  function retry() {
+    if ( initialLoad && !initialProcessingTimer ) {
+      _startInitialProcessingTimer();
+    }
+  }
+
+  return {
+    "init": init,
+    "retry": retry
+  };
+};

--- a/src/widget/rise-content-sentinel-folder.js
+++ b/src/widget/rise-content-sentinel-folder.js
@@ -1,4 +1,4 @@
-/* global riseContentSentinel, config _ */
+/* global riseContentSentinel, _ */
 /* eslint-disable no-console */
 
 var RiseVision = RiseVision || {};
@@ -275,39 +275,24 @@ RiseVision.VideoWatch.RiseContentSentinelFolder = function() {
     }
 
     switch ( data.event.toUpperCase() ) {
-      case "NO-CONNECTION":
-        _handleNoConnection();
-        break;
-      case "REQUIRED-MODULES-UNAVAILABLE":
-        _handleRequiredModulesUnavailable();
-        break;
-      case "AUTHORIZED":
-        _handleAuthorized();
-        break;
-      case "UNAUTHORIZED":
-        _handleUnauthorized();
-        break;
-      case "AUTHORIZATION-ERROR":
-        _handleAuthorizationError;
-        break;
-      case "FILE-AVAILABLE":
-        _handleFileAvailable( data );
-        break;
-      case "FILE-PROCESSING":
-        _handleFileProcessing();
-        break;
-      case "FOLDER-NO-EXIST":
-        _handleFolderNoExist();
-        break;
-      case "FOLDER-EMPTY":
-        _handleFolderEmpty();
-        break;
-      case "FILE-DELETED":
-        _handleFileDeleted( data );
-        break;
-      case "FILE-ERROR":
-        _handleFileError( data );
-        break;
+    case "FILE-AVAILABLE":
+      _handleFileAvailable( data );
+      break;
+    case "FILE-PROCESSING":
+      _handleFileProcessing();
+      break;
+    case "FOLDER-NO-EXIST":
+      _handleFolderNoExist();
+      break;
+    case "FOLDER-EMPTY":
+      _handleFolderEmpty();
+      break;
+    case "FILE-DELETED":
+      _handleFileDeleted( data );
+      break;
+    case "FILE-ERROR":
+      _handleFileError( data );
+      break;
     }
   }
 

--- a/src/widget/video-utils.js
+++ b/src/widget/video-utils.js
@@ -10,7 +10,7 @@ RiseVision.VideoUtils = ( function() {
     _companyId = null,
     _displayId = null,
     _configurationType = null,
-    _usingRLS = false,
+    _usingWatch = false,
     _params = null,
     _mode = null;
 
@@ -107,8 +107,8 @@ RiseVision.VideoUtils = ( function() {
     return "risemedialibrary-" + _params.storage.companyId + "/" + path;
   }
 
-  function getUsingRLS() {
-    return _usingRLS;
+  function getUsingWatch() {
+    return _usingWatch;
   }
 
   function isValidDisplayId() {
@@ -187,8 +187,8 @@ RiseVision.VideoUtils = ( function() {
     _params = params;
   }
 
-  function setUsingRLS() {
-    _usingRLS = true;
+  function setUsingWatch() {
+    _usingWatch = true;
   }
 
   return {
@@ -204,7 +204,7 @@ RiseVision.VideoUtils = ( function() {
     "getStorageFileName": getStorageFileName,
     "getStorageSingleFilePath": getStorageSingleFilePath,
     "getStorageFolderPath": getStorageFolderPath,
-    "getUsingRLS": getUsingRLS,
+    "getUsingWatch": getUsingWatch,
     "isValidDisplayId": isValidDisplayId,
     "logEvent": logEvent,
     "playerEnded": playerEnded,
@@ -217,7 +217,7 @@ RiseVision.VideoUtils = ( function() {
     "setCompanyId": setCompanyId,
     "setMode": setMode,
     "setParams": setParams,
-    "setUsingRLS": setUsingRLS
+    "setUsingWatch": setUsingWatch
   };
 
 } )();

--- a/src/widget/video-utils.js
+++ b/src/widget/video-utils.js
@@ -11,6 +11,7 @@ RiseVision.VideoUtils = ( function() {
     _displayId = null,
     _configurationType = null,
     _usingWatch = false,
+    _watchType = null,
     _params = null,
     _mode = null;
 
@@ -111,6 +112,10 @@ RiseVision.VideoUtils = ( function() {
     return _usingWatch;
   }
 
+  function getWatchType() {
+    return _watchType;
+  }
+
   function isValidDisplayId() {
     return _displayId && _displayId !== "preview" && _displayId !== "display_id" && _displayId.indexOf( "displayId" ) === -1;
   }
@@ -187,8 +192,9 @@ RiseVision.VideoUtils = ( function() {
     _params = params;
   }
 
-  function setUsingWatch() {
+  function setUsingWatch( watchType ) {
     _usingWatch = true;
+    _watchType = watchType;
   }
 
   return {
@@ -205,6 +211,7 @@ RiseVision.VideoUtils = ( function() {
     "getStorageSingleFilePath": getStorageSingleFilePath,
     "getStorageFolderPath": getStorageFolderPath,
     "getUsingWatch": getUsingWatch,
+    "getWatchType": getWatchType,
     "isValidDisplayId": isValidDisplayId,
     "logEvent": logEvent,
     "playerEnded": playerEnded,

--- a/src/widget/video-watch.js
+++ b/src/widget/video-watch.js
@@ -3,9 +3,9 @@
 
 var RiseVision = RiseVision || {};
 
-RiseVision.VideoRLS = {};
+RiseVision.VideoWatch = {};
 
-RiseVision.VideoRLS = ( function( window, gadgets ) {
+RiseVision.VideoWatch = ( function( window, gadgets ) {
   "use strict";
 
   var _prefs = new gadgets.Prefs(),
@@ -68,12 +68,12 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
         _videoUtils.setConfigurationType( "storage file (rls)" );
 
         // create and initialize the Storage file instance
-        _storage = new RiseVision.VideoRLS.PlayerLocalStorageFile();
+        _storage = new RiseVision.VideoWatch.PlayerLocalStorageFile();
       } else if ( _videoUtils.getMode() === "folder" ) {
         _videoUtils.setConfigurationType( "storage folder (rls)" );
 
         // create and initialize the Storage folder instance
-        _storage = new RiseVision.VideoRLS.PlayerLocalStorageFolder();
+        _storage = new RiseVision.VideoWatch.PlayerLocalStorageFolder();
       }
       _storage.init();
     }
@@ -195,7 +195,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
       currentFiles = _videoUtils.getCurrentFiles();
 
       if ( currentFiles && currentFiles.length > 0 ) {
-        _player = new RiseVision.PlayerVJS( _videoUtils.getParams(), _videoUtils.getMode(), RiseVision.VideoRLS );
+        _player = new RiseVision.PlayerVJS( _videoUtils.getParams(), _videoUtils.getMode(), RiseVision.VideoWatch );
         _player.init( currentFiles );
       }
     }
@@ -263,7 +263,7 @@ RiseVision.VideoRLS = ( function( window, gadgets ) {
     var data = _.clone( params );
 
     _videoUtils.setMode( mode );
-    _videoUtils.setUsingRLS();
+    _videoUtils.setUsingWatch();
     _videoUtils.setCompanyId( companyId );
     _videoUtils.setDisplayId( displayId );
 

--- a/test/index.html
+++ b/test/index.html
@@ -32,6 +32,7 @@
     "integration/storage-v2/version.html",
     "integration/player-local-storage/file.html",
     "integration/player-local-storage/folder.html",
+    "integration/player-local-storage/folder-one-file.html",
     "integration/player-local-storage/logging-file.html",
     "integration/player-local-storage/logging-folder.html",
     "integration/player-local-storage/messaging-file.html",

--- a/test/index.html
+++ b/test/index.html
@@ -36,7 +36,9 @@
     "integration/player-local-storage/logging-file.html",
     "integration/player-local-storage/logging-folder.html",
     "integration/player-local-storage/messaging-file.html",
-    "integration/player-local-storage/messaging-folder.html"
+    "integration/player-local-storage/messaging-folder.html",
+    "integration/rise-content-sentinel/file.html",
+    "integration/rise-content-sentinel/folder.html",
   ]);
 </script>
 </body>

--- a/test/integration/js/player-local-storage-file.js
+++ b/test/integration/js/player-local-storage-file.js
@@ -9,7 +9,7 @@ suite( "file added", function() {
   var onFileInitSpy;
 
   suiteSetup( function() {
-    onFileInitSpy = sinon.spy( RiseVision.VideoRLS, "onFileInit" );
+    onFileInitSpy = sinon.spy( RiseVision.VideoWatch, "onFileInit" );
 
     // mock receiving client-list message
     messageHandlers.forEach( function( handler ) {
@@ -50,7 +50,7 @@ suite( "file added", function() {
   } );
 
   suiteTeardown( function() {
-    RiseVision.VideoRLS.onFileInit.restore();
+    RiseVision.VideoWatch.onFileInit.restore();
   } );
 
   test( "should be able to set single video with correct url", function() {
@@ -67,11 +67,11 @@ suite( "file changed", function() {
   var refreshSpy;
 
   setup( function() {
-    refreshSpy = sinon.spy( RiseVision.VideoRLS, "onFileRefresh" );
+    refreshSpy = sinon.spy( RiseVision.VideoWatch, "onFileRefresh" );
   } );
 
   teardown( function() {
-    RiseVision.VideoRLS.onFileRefresh.restore();
+    RiseVision.VideoWatch.onFileRefresh.restore();
   } );
 
   test( "should be able to update single file url", function() {
@@ -109,13 +109,13 @@ suite( "file deleted", function() {
 
   setup( function() {
     clock = sinon.useFakeTimers();
-    sinon.spy( RiseVision.VideoRLS, "onFileDeleted" );
-    sinon.stub( RiseVision.VideoRLS, "play" );
+    sinon.spy( RiseVision.VideoWatch, "onFileDeleted" );
+    sinon.stub( RiseVision.VideoWatch, "play" );
   } );
 
   teardown( function() {
-    RiseVision.VideoRLS.onFileDeleted.restore();
-    RiseVision.VideoRLS.play.restore();
+    RiseVision.VideoWatch.onFileDeleted.restore();
+    RiseVision.VideoWatch.play.restore();
     clock.restore();
   } );
 

--- a/test/integration/js/player-local-storage-folder-one-file.js
+++ b/test/integration/js/player-local-storage-folder-one-file.js
@@ -10,7 +10,7 @@ suite( "initialized with 1 file", function() {
     clock;
 
   suiteSetup( function() {
-    onFileInitSpy = sinon.stub( RiseVision.VideoRLS, "onFileInit" );
+    onFileInitSpy = sinon.stub( RiseVision.VideoWatch, "onFileInit" );
 
     // mock receiving client-list message
     messageHandlers.forEach( function( handler ) {
@@ -23,7 +23,7 @@ suite( "initialized with 1 file", function() {
   } );
 
   suiteTeardown( function() {
-    RiseVision.VideoRLS.onFileInit.restore();
+    RiseVision.VideoWatch.onFileInit.restore();
   } );
 
   setup( function() {
@@ -68,12 +68,12 @@ suite( "initialized with 1 file", function() {
       } );
     } );
 
-    clock.tick( 7000 );
+    clock.tick( 1000 );
 
     assert( !onFileInitSpy.called, "onFileInit() is not called, processing timer still running to try and get at least 2 files" );
 
     // 15 seconds is up
-    clock.tick( 1000 );
+    clock.tick( 7000 );
 
     assert( onFileInitSpy.calledOnce, "onFileInit() called once" );
     assert.equal( onFileInitSpy.args[ 0 ][ 0 ].length, 1, "intialized with 1 file" );
@@ -86,7 +86,7 @@ suite( "file updated", function() {
 
   suiteSetup( function() {
 
-    onFileRefreshStub = sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+    onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
 
     // mock receiving file-update to notify a new file is available in this watched folder
     messageHandlers.forEach( function( handler ) {
@@ -110,7 +110,7 @@ suite( "file updated", function() {
   } );
 
   suiteTeardown( function() {
-    RiseVision.VideoRLS.onFileRefresh.restore();
+    RiseVision.VideoWatch.onFileRefresh.restore();
   } );
 
   test( "should be able to configure player with an updated version of the one file in folder", function() {

--- a/test/integration/js/player-local-storage-folder.js
+++ b/test/integration/js/player-local-storage-folder.js
@@ -9,7 +9,7 @@ suite( "files initialized", function() {
   var onFileInitSpy;
 
   suiteSetup( function() {
-    onFileInitSpy = sinon.stub( RiseVision.VideoRLS, "onFileInit" );
+    onFileInitSpy = sinon.stub( RiseVision.VideoWatch, "onFileInit" );
 
     // mock receiving client-list message
     messageHandlers.forEach( function( handler ) {
@@ -66,7 +66,7 @@ suite( "files initialized", function() {
   } );
 
   suiteTeardown( function() {
-    RiseVision.VideoRLS.onFileInit.restore();
+    RiseVision.VideoWatch.onFileInit.restore();
   } );
 
   test( "should be able to configure player with correct urls", function() {
@@ -83,7 +83,7 @@ suite( "file added", function() {
 
   suiteSetup( function() {
 
-    onFileRefreshStub = sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+    onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
 
     // mock receiving file-update to notify a new file is available in this watched folder
     messageHandlers.forEach( function( handler ) {
@@ -107,7 +107,7 @@ suite( "file added", function() {
   } );
 
   suiteTeardown( function() {
-    RiseVision.VideoRLS.onFileRefresh.restore();
+    RiseVision.VideoWatch.onFileRefresh.restore();
   } );
 
   test( "should be able to configure player with an additional video", function() {
@@ -123,7 +123,7 @@ suite( "file updated", function() {
 
   suiteSetup( function() {
 
-    onFileRefreshStub = sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+    onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
 
     // mock receiving file-update to notify a new file is available in this watched folder
     messageHandlers.forEach( function( handler ) {
@@ -147,7 +147,7 @@ suite( "file updated", function() {
   } );
 
   suiteTeardown( function() {
-    RiseVision.VideoRLS.onFileRefresh.restore();
+    RiseVision.VideoWatch.onFileRefresh.restore();
   } );
 
   test( "should be able to configure player with an updated video", function() {
@@ -163,7 +163,7 @@ suite( "file deleted", function() {
 
   suiteSetup( function() {
 
-    onFileRefreshStub = sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+    onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
 
     // mock receiving file-update to notify a new file is available in this watched folder
     messageHandlers.forEach( function( handler ) {
@@ -177,7 +177,7 @@ suite( "file deleted", function() {
   } );
 
   suiteTeardown( function() {
-    RiseVision.VideoRLS.onFileRefresh.restore();
+    RiseVision.VideoWatch.onFileRefresh.restore();
   } );
 
   test( "should be able to configure player after a video was deleted", function() {
@@ -192,7 +192,7 @@ suite( "file error from update", function() {
 
   suiteSetup( function() {
 
-    onFileRefreshStub = sinon.stub( RiseVision.VideoRLS, "onFileRefresh" );
+    onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
 
     // mock adding this file
     messageHandlers.forEach( function( handler ) {
@@ -216,7 +216,7 @@ suite( "file error from update", function() {
   } );
 
   suiteTeardown( function() {
-    RiseVision.VideoRLS.onFileRefresh.restore();
+    RiseVision.VideoWatch.onFileRefresh.restore();
   } );
 
   test( "should be able to configure player after file error received for one of the videos in list", function() {

--- a/test/integration/js/player-local-storage-logging-file.js
+++ b/test/integration/js/player-local-storage-logging-file.js
@@ -19,7 +19,7 @@ var table = "video_v2_events",
   logSpy,
   check = function( done ) {
     if ( ready ) {
-      sinon.stub( RiseVision.VideoRLS, "play" );
+      sinon.stub( RiseVision.VideoWatch, "play" );
       done();
     } else {
       setTimeout( function() {
@@ -223,7 +223,7 @@ suite( "errors", function() {
   } );
 
   test( "file deleted", function() {
-    var onDeleteStub = sinon.stub( RiseVision.VideoRLS, "onFileDeleted" );
+    var onDeleteStub = sinon.stub( RiseVision.VideoWatch, "onFileDeleted" );
 
     logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 

--- a/test/integration/js/player-local-storage-logging-folder.js
+++ b/test/integration/js/player-local-storage-logging-folder.js
@@ -19,7 +19,7 @@ var table = "video_v2_events",
   logSpy,
   check = function( done ) {
     if ( ready ) {
-      sinon.stub( RiseVision.VideoRLS, "play" );
+      sinon.stub( RiseVision.VideoWatch, "play" );
       done();
     } else {
       setTimeout( function() {
@@ -288,7 +288,7 @@ suite( "errors", function() {
 suite( "folder file deleted", function() {
   test( "should log when a file in folder is deleted", function() {
     var logParams = JSON.parse( JSON.stringify( params ) ),
-      onFilesRemovedStub = sinon.stub( RiseVision.VideoRLS, "onFolderFilesRemoved" );
+      onFilesRemovedStub = sinon.stub( RiseVision.VideoWatch, "onFolderFilesRemoved" );
 
     logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 

--- a/test/integration/js/player-local-storage-messaging-file.js
+++ b/test/integration/js/player-local-storage-messaging-file.js
@@ -30,12 +30,12 @@ suite( "file downloading", function() {
 
   setup( function() {
     clock = sinon.useFakeTimers();
-    sinon.stub( RiseVision.VideoRLS, "play" );
+    sinon.stub( RiseVision.VideoWatch, "play" );
   } );
 
   teardown( function() {
     clock.restore();
-    RiseVision.VideoRLS.play.restore();
+    RiseVision.VideoWatch.play.restore();
   } );
 
   test( "should show message after 15 seconds of processing", function() {
@@ -77,11 +77,11 @@ suite( "file downloading", function() {
 
 suite( "errors", function() {
   setup( function() {
-    sinon.stub( RiseVision.VideoRLS, "play" );
+    sinon.stub( RiseVision.VideoWatch, "play" );
   } );
 
   teardown( function() {
-    RiseVision.VideoRLS.play.restore();
+    RiseVision.VideoWatch.play.restore();
   } );
 
   test( "nothing is displayed", function() {

--- a/test/integration/js/player-local-storage-messaging-folder.js
+++ b/test/integration/js/player-local-storage-messaging-folder.js
@@ -30,12 +30,12 @@ suite( "files downloading", function() {
 
   setup( function() {
     clock = sinon.useFakeTimers();
-    sinon.stub( RiseVision.VideoRLS, "play" );
+    sinon.stub( RiseVision.VideoWatch, "play" );
   } );
 
   teardown( function() {
     clock.restore();
-    RiseVision.VideoRLS.play.restore();
+    RiseVision.VideoWatch.play.restore();
   } );
 
   test( "should show message after 15 seconds of processing", function() {
@@ -94,12 +94,12 @@ suite( "files downloading", function() {
 suite( "errors", function() {
   setup( function() {
     clock = sinon.useFakeTimers();
-    sinon.stub( RiseVision.VideoRLS, "play" );
+    sinon.stub( RiseVision.VideoWatch, "play" );
   } );
 
   teardown( function() {
     clock.restore();
-    RiseVision.VideoRLS.play.restore();
+    RiseVision.VideoWatch.play.restore();
   } );
 
   test( "nothing is displayed", function() {

--- a/test/integration/js/player-local-storage-stubs.js
+++ b/test/integration/js/player-local-storage-stubs.js
@@ -22,12 +22,12 @@ top.RiseVision.Viewer.LocalMessaging = {
   }
 };
 
-sinon.stub( RiseVision.VideoRLS, "setAdditionalParams", function( params, mode, displayId ) {
+sinon.stub( RiseVision.VideoWatch, "setAdditionalParams", function( params, mode, displayId ) {
   ready = true; // eslint-disable-line no-undef
   // spy on log call
   logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" ); // eslint-disable-line no-undef
 
-  RiseVision.VideoRLS.setAdditionalParams.restore();
+  RiseVision.VideoWatch.setAdditionalParams.restore();
   // override company id to be the same company from the test data to bypass making direct licensing authorization request
-  RiseVision.VideoRLS.setAdditionalParams( params, mode, displayId, "b428b4e8-c8b9-41d5-8a10-b4193c789443" );
+  RiseVision.VideoWatch.setAdditionalParams( params, mode, displayId, "b428b4e8-c8b9-41d5-8a10-b4193c789443", "rls" );
 } );

--- a/test/integration/js/rise-content-sentinel-file.js
+++ b/test/integration/js/rise-content-sentinel-file.js
@@ -1,47 +1,46 @@
-/* global suiteSetup, suite, setup, teardown, test, assert, suiteTeardown,
+/* global suiteSetup, suite, test, assert, suiteTeardown,
  RiseVision, sinon */
 
 /* eslint-disable func-names */
 
-var receivedCounter = 0;
-var receivedExpected = 0;
-var callback = null;
+var receivedCounter = 0,
+  receivedExpected = 0,
+  callback = null,
+  receivedHandler = function() {
+    if ( event.data.topic.indexOf( "FILE-" ) !== -1 ) {
+      receivedCounter += 1;
 
-var receivedHandler = function() {
-  if (event.data.topic.indexOf("FILE-") !== -1) {
-    receivedCounter += 1;
-
-    if (receivedCounter === receivedExpected) {
-      callback && callback();
+      if ( receivedCounter === receivedExpected ) {
+        callback && callback();
+      }
     }
-  }
-};
+  };
 
-window.addEventListener("message", function(event) {
+window.addEventListener( "message", function() {
   receivedHandler();
-});
+} );
 
 suite( "file added", function() {
   var onFileInitSpy;
 
-  suiteSetup( function(done) {
+  suiteSetup( function( done ) {
     onFileInitSpy = sinon.spy( RiseVision.VideoWatch, "onFileInit" );
 
     receivedExpected = 2;
     callback = done;
 
     // mock receiving file-update to notify file is downloading
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
       status: "STALE"
-    }, "*");
+    }, "*" );
 
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
       status: "CURRENT"
-    }, "*");
+    }, "*" );
   } );
 
   suiteTeardown( function() {
@@ -64,25 +63,25 @@ suite( "file added", function() {
 suite( "file changed", function() {
   var refreshSpy;
 
-  suiteSetup( function(done) {
+  suiteSetup( function( done ) {
     refreshSpy = sinon.spy( RiseVision.VideoWatch, "onFileRefresh" );
 
     receivedExpected = 2;
     callback = done;
 
     // mock receiving file-update to notify file is downloading
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
       status: "STALE"
-    }, "*");
+    }, "*" );
 
     // mock receiving file-update to notify file is available
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
       status: "CURRENT"
-    }, "*");
+    }, "*" );
   } );
 
   suiteTeardown( function() {
@@ -105,7 +104,7 @@ suite( "file changed", function() {
 suite( "file deleted", function() {
   var clock;
 
-  suiteSetup( function(done) {
+  suiteSetup( function( done ) {
     clock = sinon.useFakeTimers();
     sinon.spy( RiseVision.VideoWatch, "onFileDeleted" );
     sinon.stub( RiseVision.VideoWatch, "play" );
@@ -114,11 +113,11 @@ suite( "file deleted", function() {
     callback = done;
 
     // mock receiving file-update to notify file is downloading
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
       status: "DELETED"
-    }, "*");
+    }, "*" );
   } );
 
   suiteTeardown( function() {

--- a/test/integration/js/rise-content-sentinel-file.js
+++ b/test/integration/js/rise-content-sentinel-file.js
@@ -1,0 +1,140 @@
+/* global suiteSetup, suite, setup, teardown, test, assert, suiteTeardown,
+ RiseVision, sinon */
+
+/* eslint-disable func-names */
+
+var receivedCounter = 0;
+var receivedExpected = 0;
+var callback = null;
+
+var receivedHandler = function() {
+  if (event.data.topic.indexOf("FILE-") !== -1) {
+    receivedCounter += 1;
+
+    if (receivedCounter === receivedExpected) {
+      callback && callback();
+    }
+  }
+};
+
+window.addEventListener("message", function(event) {
+  receivedHandler();
+});
+
+suite( "file added", function() {
+  var onFileInitSpy;
+
+  suiteSetup( function(done) {
+    onFileInitSpy = sinon.spy( RiseVision.VideoWatch, "onFileInit" );
+
+    receivedExpected = 2;
+    callback = done;
+
+    // mock receiving file-update to notify file is downloading
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+      status: "STALE"
+    }, "*");
+
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+      status: "CURRENT"
+    }, "*");
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoWatch.onFileInit.restore();
+    receivedCounter = 0;
+    receivedExpected = 0;
+    callback = null;
+  } );
+
+  test( "should be able to set single video with correct url", function() {
+    assert( onFileInitSpy.calledOnce, "onFileInit() called once" );
+    assert( onFileInitSpy.calledWith( {
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+      name: "a_food_show.webm",
+      url: "https://widgets.risevision.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm"
+    } ), "onFileInit() called with correct data" );
+  } );
+} );
+
+suite( "file changed", function() {
+  var refreshSpy;
+
+  suiteSetup( function(done) {
+    refreshSpy = sinon.spy( RiseVision.VideoWatch, "onFileRefresh" );
+
+    receivedExpected = 2;
+    callback = done;
+
+    // mock receiving file-update to notify file is downloading
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+      status: "STALE"
+    }, "*");
+
+    // mock receiving file-update to notify file is available
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+      status: "CURRENT"
+    }, "*");
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoWatch.onFileRefresh.restore();
+    receivedCounter = 0;
+    receivedExpected = 0;
+    callback = null;
+  } );
+
+  test( "should be able to update single file url", function() {
+    assert( refreshSpy.calledOnce );
+    assert( refreshSpy.calledWith( {
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+      name: "a_food_show.webm",
+      url: "https://widgets.risevision.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm"
+    } ), "onFileRefresh() called with correct data" );
+  } );
+} );
+
+suite( "file deleted", function() {
+  var clock;
+
+  suiteSetup( function(done) {
+    clock = sinon.useFakeTimers();
+    sinon.spy( RiseVision.VideoWatch, "onFileDeleted" );
+    sinon.stub( RiseVision.VideoWatch, "play" );
+
+    receivedExpected = 1;
+    callback = done;
+
+    // mock receiving file-update to notify file is downloading
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+      status: "DELETED"
+    }, "*");
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoWatch.onFileDeleted.restore();
+    RiseVision.VideoWatch.play.restore();
+    clock.restore();
+    receivedCounter = 0;
+    receivedExpected = 0;
+    callback = null;
+  } );
+
+  test( "should dispose of the video player", function() {
+    clock.tick( 500 );
+
+    assert.isNotNull( document.querySelector( "video#player" ), "video element is showing" );
+    assert.isNull( document.querySelector( "video#player_html5_api" ), "video player is not showing" );
+
+  } );
+} );

--- a/test/integration/js/rise-content-sentinel-folder.js
+++ b/test/integration/js/rise-content-sentinel-folder.js
@@ -1,0 +1,244 @@
+/* global suiteSetup, suite, test, assert, suiteTeardown,
+ RiseVision, sinon */
+
+/* eslint-disable func-names */
+
+var receivedCounter = 0;
+var receivedExpected = 0;
+var callback = null;
+
+var receivedHandler = function() {
+  if (event.data.topic.indexOf("FILE-") !== -1) {
+    receivedCounter += 1;
+
+    if (receivedCounter === receivedExpected) {
+      callback && callback();
+    }
+  }
+};
+
+window.addEventListener("message", function(event) {
+  receivedHandler();
+});
+
+
+suite( "files initialized", function() {
+  var onFileInitSpy;
+
+  suiteSetup( function(done) {
+    onFileInitSpy = sinon.stub( RiseVision.VideoWatch, "onFileInit" );
+
+    receivedExpected = 4;
+
+    callback = done;
+
+    // mock receiving file-update to notify file is downloading
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-c.webm",
+      status: "STALE"
+    }, "*");
+
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+      status: "STALE"
+    }, "*");
+
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-c.webm",
+      status: "CURRENT"
+    }, "*");
+
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+      status: "CURRENT"
+    }, "*");
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoWatch.onFileInit.restore();
+    receivedCounter = 0;
+    receivedExpected = 0;
+    callback = null;
+  } );
+
+  test( "should be able to configure player with correct urls", function() {
+    assert( onFileInitSpy.calledOnce, "onFileInit() called once" );
+    assert.equal( onFileInitSpy.args[ 0 ][ 0 ].length, 2, "intialized with 2 files" );
+    assert.equal( onFileInitSpy.args[ 0 ][ 0 ][ 0 ].filePath, "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm", "file are sorted alphabetically ascending" );
+    assert.equal( onFileInitSpy.args[ 0 ][ 0 ][ 0 ].url, "https://widgets.risevision.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm", "file 1 url is correct" );
+    assert.equal( onFileInitSpy.args[ 0 ][ 0 ][ 1 ].url, "https://widgets.risevision.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-c.webm", "file 2 url is correct" );
+  } );
+} );
+
+suite( "file added", function() {
+  var onFileRefreshStub;
+
+  suiteSetup( function(done) {
+
+    onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
+
+    receivedExpected = 2;
+
+    callback = done;
+
+    // mock receiving file-update to notify a new file is available in this watched folder
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+      status: "STALE"
+    }, "*");
+
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+      status: "CURRENT"
+    }, "*");
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoWatch.onFileRefresh.restore();
+    receivedCounter = 0;
+    receivedExpected = 0;
+    callback = null;
+  } );
+
+  test( "should be able to configure player with an additional video", function() {
+    assert( onFileRefreshStub.calledOnce, "onFileRefresh() called once" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ].length, 3, "refreshed with 3 files" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 1 ].filePath, "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm", "file are sorted alphabetically ascending" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 1 ].url, "https://widgets.risevision.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm", "file url is correct" );
+  } );
+} );
+
+suite( "file updated", function() {
+  var onFileRefreshStub;
+
+  suiteSetup( function(done) {
+
+    onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
+
+    receivedExpected = 2;
+    callback = done;
+
+    // mock receiving file-update to notify a new file is available in this watched folder
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+      status: "STALE"
+    }, "*");
+
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
+      status: "CURRENT"
+    }, "*");
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoWatch.onFileRefresh.restore();
+    receivedCounter = 0;
+    receivedExpected = 0;
+    callback = null;
+  } );
+
+  test( "should be able to configure player with an updated video", function() {
+    assert( onFileRefreshStub.calledOnce, "onFileRefresh() called once" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ].length, 3, "refreshed with 3 files" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 0 ].filePath, "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm", "files remain sorted alphabetically ascending" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 0 ].url, "https://widgets.risevision.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm", "updated file url is correct" );
+  } );
+} );
+
+suite( "file deleted", function() {
+  var onFileRefreshStub;
+
+  suiteSetup( function(done) {
+
+    onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
+
+    receivedExpected = 1;
+    callback = done;
+
+    // mock receiving file-update to notify a new file is available in this watched folder
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+      status: "DELETED"
+    }, "*");
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoWatch.onFileRefresh.restore();
+    receivedCounter = 0;
+    receivedExpected = 0;
+    callback = null;
+  } );
+
+  test( "should be able to configure player after a video was deleted", function() {
+    assert( onFileRefreshStub.calledOnce, "onFileRefresh() called once" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ].length, 2, "refreshed with 2 files" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 1 ].filePath, "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-c.webm", "files remain sorted alphabetically ascending" );
+  } );
+} );
+
+suite( "file error from update", function() {
+  var onFileRefreshStub;
+
+  suiteSetup( function(done) {
+
+    onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
+
+    receivedExpected = 2;
+    callback = done;
+
+    // mock adding this file
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+      status: "STALE"
+    }, "*");
+
+    window.postMessage({
+      topic: "FILE-UPDATE",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+      status: "CURRENT"
+    }, "*");
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.VideoWatch.onFileRefresh.restore();
+  } );
+
+  test( "should be able to configure player after file error received for one of the videos in list", function(done) {
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ].length, 3, "refreshed with 3 files" );
+    assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 1 ].url, "https://widgets.risevision.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm", "file 3 url is correct" );
+
+    receivedCounter = 0;
+    receivedExpected = 1;
+    callback = function () {
+      // file should be removed from list provided to onFileRefresh()
+      setTimeout(function() {
+        assert( onFileRefreshStub.calledTwice, "onFileRefresh() called twice" );
+        assert.equal( onFileRefreshStub.args[ 1 ][ 0 ].length, 2, "refreshed with 2 files" );
+        assert.equal( onFileRefreshStub.args[ 1 ][ 0 ][ 1 ].url, "https://widgets.risevision.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-c.webm", "file 2 url is correct" );
+        done();
+      },200);
+    };
+
+    // mock FILE-ERROR for this image
+    window.postMessage({
+      topic: "FILE-ERROR",
+      filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
+      msg: "Insufficient disk space"
+    }, "*");
+  } );
+} );

--- a/test/integration/js/rise-content-sentinel-folder.js
+++ b/test/integration/js/rise-content-sentinel-folder.js
@@ -3,29 +3,28 @@
 
 /* eslint-disable func-names */
 
-var receivedCounter = 0;
-var receivedExpected = 0;
-var callback = null;
+var receivedCounter = 0,
+  receivedExpected = 0,
+  callback = null,
+  receivedHandler = function() {
+    if ( event.data.topic.indexOf( "FILE-" ) !== -1 ) {
+      receivedCounter += 1;
 
-var receivedHandler = function() {
-  if (event.data.topic.indexOf("FILE-") !== -1) {
-    receivedCounter += 1;
-
-    if (receivedCounter === receivedExpected) {
-      callback && callback();
+      if ( receivedCounter === receivedExpected ) {
+        callback && callback();
+      }
     }
-  }
-};
+  };
 
-window.addEventListener("message", function(event) {
+window.addEventListener( "message", function() {
   receivedHandler();
-});
+} );
 
 
 suite( "files initialized", function() {
   var onFileInitSpy;
 
-  suiteSetup( function(done) {
+  suiteSetup( function( done ) {
     onFileInitSpy = sinon.stub( RiseVision.VideoWatch, "onFileInit" );
 
     receivedExpected = 4;
@@ -33,29 +32,29 @@ suite( "files initialized", function() {
     callback = done;
 
     // mock receiving file-update to notify file is downloading
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-c.webm",
       status: "STALE"
-    }, "*");
+    }, "*" );
 
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
       status: "STALE"
-    }, "*");
+    }, "*" );
 
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-c.webm",
       status: "CURRENT"
-    }, "*");
+    }, "*" );
 
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
       status: "CURRENT"
-    }, "*");
+    }, "*" );
 
   } );
 
@@ -78,7 +77,7 @@ suite( "files initialized", function() {
 suite( "file added", function() {
   var onFileRefreshStub;
 
-  suiteSetup( function(done) {
+  suiteSetup( function( done ) {
 
     onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
 
@@ -87,17 +86,17 @@ suite( "file added", function() {
     callback = done;
 
     // mock receiving file-update to notify a new file is available in this watched folder
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
       status: "STALE"
-    }, "*");
+    }, "*" );
 
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
       status: "CURRENT"
-    }, "*");
+    }, "*" );
 
   } );
 
@@ -119,7 +118,7 @@ suite( "file added", function() {
 suite( "file updated", function() {
   var onFileRefreshStub;
 
-  suiteSetup( function(done) {
+  suiteSetup( function( done ) {
 
     onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
 
@@ -127,17 +126,17 @@ suite( "file updated", function() {
     callback = done;
 
     // mock receiving file-update to notify a new file is available in this watched folder
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
       status: "STALE"
-    }, "*");
+    }, "*" );
 
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-a.webm",
       status: "CURRENT"
-    }, "*");
+    }, "*" );
 
   } );
 
@@ -159,7 +158,7 @@ suite( "file updated", function() {
 suite( "file deleted", function() {
   var onFileRefreshStub;
 
-  suiteSetup( function(done) {
+  suiteSetup( function( done ) {
 
     onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
 
@@ -167,11 +166,11 @@ suite( "file deleted", function() {
     callback = done;
 
     // mock receiving file-update to notify a new file is available in this watched folder
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
       status: "DELETED"
-    }, "*");
+    }, "*" );
 
   } );
 
@@ -192,7 +191,7 @@ suite( "file deleted", function() {
 suite( "file error from update", function() {
   var onFileRefreshStub;
 
-  suiteSetup( function(done) {
+  suiteSetup( function( done ) {
 
     onFileRefreshStub = sinon.stub( RiseVision.VideoWatch, "onFileRefresh" );
 
@@ -200,17 +199,17 @@ suite( "file error from update", function() {
     callback = done;
 
     // mock adding this file
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
       status: "STALE"
-    }, "*");
+    }, "*" );
 
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-UPDATE",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
       status: "CURRENT"
-    }, "*");
+    }, "*" );
 
   } );
 
@@ -218,27 +217,27 @@ suite( "file error from update", function() {
     RiseVision.VideoWatch.onFileRefresh.restore();
   } );
 
-  test( "should be able to configure player after file error received for one of the videos in list", function(done) {
+  test( "should be able to configure player after file error received for one of the videos in list", function( done ) {
     assert.equal( onFileRefreshStub.args[ 0 ][ 0 ].length, 3, "refreshed with 3 files" );
     assert.equal( onFileRefreshStub.args[ 0 ][ 0 ][ 1 ].url, "https://widgets.risevision.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm", "file 3 url is correct" );
 
     receivedCounter = 0;
     receivedExpected = 1;
-    callback = function () {
+    callback = function() {
       // file should be removed from list provided to onFileRefresh()
-      setTimeout(function() {
+      setTimeout( function() {
         assert( onFileRefreshStub.calledTwice, "onFileRefresh() called twice" );
         assert.equal( onFileRefreshStub.args[ 1 ][ 0 ].length, 2, "refreshed with 2 files" );
         assert.equal( onFileRefreshStub.args[ 1 ][ 0 ][ 1 ].url, "https://widgets.risevision.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-c.webm", "file 2 url is correct" );
         done();
-      },200);
+      }, 200 );
     };
 
     // mock FILE-ERROR for this image
-    window.postMessage({
+    window.postMessage( {
       topic: "FILE-ERROR",
       filePath: "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/test-file-b.webm",
       msg: "Insufficient disk space"
-    }, "*");
+    }, "*" );
   } );
 } );

--- a/test/integration/js/rise-content-sentinel-stubs.js
+++ b/test/integration/js/rise-content-sentinel-stubs.js
@@ -1,0 +1,18 @@
+/* global RiseVision, sinon, config */
+
+/* eslint-disable func-names, no-global-assign */
+
+config.TEST_USE_SENTINEL = true;
+
+sinon.stub( RiseVision.Common.Utilities, "isServiceWorkerRegistered", function() {
+  return Promise.resolve();
+} )
+
+sinon.stub( RiseVision.VideoWatch, "setAdditionalParams", function( params, mode, displayId ) {
+  ready = true; // eslint-disable-line no-undef
+  // spy on log call
+  logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" ); // eslint-disable-line no-undef
+
+  RiseVision.VideoWatch.setAdditionalParams.restore();
+  RiseVision.VideoWatch.setAdditionalParams( params, mode, displayId, "b428b4e8-c8b9-41d5-8a10-b4193c789443", "sentinel" );
+} );

--- a/test/integration/non-storage/file.html
+++ b/test/integration/non-storage/file.html
@@ -79,6 +79,25 @@
     });
 
     suite( "VideoJS options", function() {
+      function checkPlayerLoaded(done) {
+        var elemToObserve = document.getElementById("player");
+        var callback = function(mutations) {
+          for (var mutation of mutations) {
+            if(mutation.attributeName === "class"){
+              observer.disconnect();
+              done();
+              break;
+            }
+          }
+        };
+        var observer = new MutationObserver(callback);
+        observer.observe(elemToObserve, {attributes: true});
+      }
+
+      suiteSetup(function(done) {
+        checkPlayerLoaded(done);
+      });
+
       test( "should add controls to video", function() {
         assert.isNotNull( document.querySelector("#player.vjs-controls-enabled") );
       } );

--- a/test/integration/non-storage/logging.html
+++ b/test/integration/non-storage/logging.html
@@ -92,6 +92,24 @@
     });
 
     suite("configuration", function () {
+      function checkPlayerLoaded(done) {
+        var elemToObserve = document.getElementById("player");
+        var callback = function(mutations) {
+          for (var mutation of mutations) {
+            if(mutation.attributeName === "class"){
+              observer.disconnect();
+              done();
+              break;
+            }
+          }
+        };
+        var observer = new MutationObserver(callback);
+        observer.observe(elemToObserve, {attributes: true});
+      }
+
+      suiteSetup(function(done) {
+        checkPlayerLoaded(done);
+      });
 
       test("should log the configuration event", function () {
         assert(spy.calledWith(table, {

--- a/test/integration/non-storage/pre-merge.html
+++ b/test/integration/non-storage/pre-merge.html
@@ -79,6 +79,25 @@
     suite("non-storage initialization - file added", function () {
       var onInitSpy = sinon.spy(RiseVision.Video, "onFileInit");
 
+      function checkPlayerLoaded(done) {
+        var elemToObserve = document.getElementById("player");
+        var callback = function(mutations) {
+          for (var mutation of mutations) {
+            if(mutation.attributeName === "class"){
+              observer.disconnect();
+              done();
+              break;
+            }
+          }
+        };
+        var observer = new MutationObserver(callback);
+        observer.observe(elemToObserve, {attributes: true});
+      }
+
+      suiteSetup(function(done) {
+        checkPlayerLoaded(done);
+      });
+
       suiteTeardown(function() {
         RiseVision.Video.onFileInit.restore();
       });

--- a/test/integration/player-local-storage/file.html
+++ b/test/integration/player-local-storage/file.html
@@ -34,7 +34,7 @@
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/video-utils.js"></script>
-<script src="../../../src/widget/video-rls.js"></script>
+<script src="../../../src/widget/video-watch.js"></script>
 <script src="../../../src/widget/player-utils.js"></script>
 <script src="../../../src/widget/player-vjs.js"></script>
 <script src="../../../src/widget/player-local-storage-file.js"></script>

--- a/test/integration/player-local-storage/folder-one-file.html
+++ b/test/integration/player-local-storage/folder-one-file.html
@@ -34,7 +34,7 @@
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/video-utils.js"></script>
-<script src="../../../src/widget/video-rls.js"></script>
+<script src="../../../src/widget/video-watch.js"></script>
 <script src="../../../src/widget/player-utils.js"></script>
 <script src="../../../src/widget/player-vjs.js"></script>
 <script src="../../../src/widget/player-local-storage-folder.js"></script>

--- a/test/integration/player-local-storage/folder.html
+++ b/test/integration/player-local-storage/folder.html
@@ -34,7 +34,7 @@
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/video-utils.js"></script>
-<script src="../../../src/widget/video-rls.js"></script>
+<script src="../../../src/widget/video-watch.js"></script>
 <script src="../../../src/widget/player-utils.js"></script>
 <script src="../../../src/widget/player-vjs.js"></script>
 <script src="../../../src/widget/player-local-storage-folder.js"></script>

--- a/test/integration/player-local-storage/logging-file.html
+++ b/test/integration/player-local-storage/logging-file.html
@@ -34,7 +34,7 @@
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/video-utils.js"></script>
-<script src="../../../src/widget/video-rls.js"></script>
+<script src="../../../src/widget/video-watch.js"></script>
 <script src="../../../src/widget/player-utils.js"></script>
 <script src="../../../src/widget/player-vjs.js"></script>
 <script src="../../../src/widget/player-local-storage-file.js"></script>

--- a/test/integration/player-local-storage/logging-folder.html
+++ b/test/integration/player-local-storage/logging-folder.html
@@ -34,7 +34,7 @@
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/video-utils.js"></script>
-<script src="../../../src/widget/video-rls.js"></script>
+<script src="../../../src/widget/video-watch.js"></script>
 <script src="../../../src/widget/player-utils.js"></script>
 <script src="../../../src/widget/player-vjs.js"></script>
 <script src="../../../src/widget/player-local-storage-folder.js"></script>

--- a/test/integration/player-local-storage/messaging-file.html
+++ b/test/integration/player-local-storage/messaging-file.html
@@ -34,7 +34,7 @@
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/video-utils.js"></script>
-<script src="../../../src/widget/video-rls.js"></script>
+<script src="../../../src/widget/video-watch.js"></script>
 <script src="../../../src/widget/player-utils.js"></script>
 <script src="../../../src/widget/player-vjs.js"></script>
 <script src="../../../src/widget/player-local-storage-file.js"></script>

--- a/test/integration/player-local-storage/messaging-folder.html
+++ b/test/integration/player-local-storage/messaging-folder.html
@@ -34,7 +34,7 @@
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/video-utils.js"></script>
-<script src="../../../src/widget/video-rls.js"></script>
+<script src="../../../src/widget/video-watch.js"></script>
 <script src="../../../src/widget/player-utils.js"></script>
 <script src="../../../src/widget/player-vjs.js"></script>
 <script src="../../../src/widget/player-local-storage-folder.js"></script>

--- a/test/integration/rise-content-sentinel/file.html
+++ b/test/integration/rise-content-sentinel/file.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Video Widget</title>
+
+  <script src="../../../src/components/web-component-tester/browser.js"></script>
+
+  <link rel="stylesheet" type="text/css" href="../../../src/components/videojs/dist/video-js.css">
+  <link rel="stylesheet" type="text/css" href="../../../src/widget/css/video.css">
+  <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
+</head>
+<body>
+
+<div id="container">
+  <video id="player" class="video-js" preload="auto"></video>
+</div>
+
+<div id="messageContainer"></div>
+
+<script src="../../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
+<script src="../../../node_modules/widget-tester/mocks/logger-mock.js"></script>
+
+<script src="../../../src/components/videojs/dist/video.min.js"></script>
+<script src="../../../src/components/underscore/underscore-min.js"></script>
+
+<script src="../../../src/components/widget-common/dist/config.js"></script>
+<script src="../../../src/components/widget-common/dist/common.js"></script>
+<script src="../../../src/common-modules/rise-content-sentinel.js"></script>
+<script src="../../../src/components/widget-common/dist/message.js"></script>
+<script src="../../../src/config/version.js"></script>
+<script src="../../../src/config/test.js"></script>
+<script src="../../../src/widget/video-utils.js"></script>
+<script src="../../../src/widget/video-watch.js"></script>
+<script src="../../../src/widget/player-utils.js"></script>
+<script src="../../../src/widget/player-vjs.js"></script>
+<script src="../../../src/widget/rise-content-sentinel-file.js"></script>
+
+<script type="text/javascript">
+  config.COMPONENTS_PATH = "../../../src/components/";
+</script>
+
+<script src="../../data/storage-file.js"></script>
+<script src="../js/rise-content-sentinel-file.js"></script>
+<script src="../js/rise-content-sentinel-stubs.js"></script>
+<script src="../../../src/widget/main.js"></script>
+
+</body>
+</html>

--- a/test/integration/rise-content-sentinel/folder.html
+++ b/test/integration/rise-content-sentinel/folder.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Video Widget</title>
+
+  <script src="../../../src/components/web-component-tester/browser.js"></script>
+
+  <link rel="stylesheet" type="text/css" href="../../../src/components/videojs/dist/video-js.css">
+  <link rel="stylesheet" type="text/css" href="../../../src/widget/css/video.css">
+  <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
+</head>
+<body>
+
+<div id="container">
+  <video id="player" class="video-js" preload="auto"></video>
+</div>
+
+<div id="messageContainer"></div>
+
+<script src="../../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
+<script src="../../../node_modules/widget-tester/mocks/logger-mock.js"></script>
+
+<script src="../../../src/components/videojs/dist/video.min.js"></script>
+<script src="../../../src/components/underscore/underscore-min.js"></script>
+
+<script src="../../../src/components/widget-common/dist/config.js"></script>
+<script src="../../../src/components/widget-common/dist/common.js"></script>
+<script src="../../../src/common-modules/rise-content-sentinel.js"></script>
+<script src="../../../src/components/widget-common/dist/message.js"></script>
+<script src="../../../src/config/version.js"></script>
+<script src="../../../src/config/test.js"></script>
+<script src="../../../src/widget/video-utils.js"></script>
+<script src="../../../src/widget/video-watch.js"></script>
+<script src="../../../src/widget/player-utils.js"></script>
+<script src="../../../src/widget/player-vjs.js"></script>
+<script src="../../../src/widget/rise-content-sentinel-folder.js"></script>
+
+<script type="text/javascript">
+  config.COMPONENTS_PATH = "../../../src/components/";
+</script>
+
+<script src="../../data/storage-folder.js"></script>
+<script src="../js/rise-content-sentinel-folder.js"></script>
+<script src="../js/rise-content-sentinel-stubs.js"></script>
+<script src="../../../src/widget/main.js"></script>
+
+</body>
+</html>

--- a/test/integration/video-utils.html
+++ b/test/integration/video-utils.html
@@ -102,14 +102,14 @@
 
     suite( "setCurrentFiles", function() {
 
-      test( "should handle string type (non RLS single file)", function() {
+      test( "should handle string type (non Watch single file)", function() {
         videoUtils.setCurrentFiles( "test-bucket/video.webm" );
 
         expect( videoUtils.getCurrentFiles().length ).to.equal( 1 );
         expect( videoUtils.getCurrentFiles()[ 0 ] ).to.equal( "test-bucket/video.webm" );
       } );
 
-      test( "should handle array type (folder or RLS single file)", function() {
+      test( "should handle array type (watch folder or single file)", function() {
         videoUtils.setCurrentFiles( [ "test-bucket/video.webm", "test-bucket/video2.webm" ] );
 
         expect( videoUtils.getCurrentFiles().length ).to.equal( 2 );

--- a/test/unit/widget/video-watch-spec.js
+++ b/test/unit/widget/video-watch-spec.js
@@ -24,7 +24,7 @@ describe( "onFileRefresh", function() {
   } );
 
   it( "should not play if viewer is paused", function() {
-    RiseVision.VideoRLS.onFileRefresh( [ "url1" ] );
+    RiseVision.VideoWatch.onFileRefresh( [ "url1" ] );
 
     expect( player.init ).to.not.have.been.called;
   } );
@@ -32,34 +32,34 @@ describe( "onFileRefresh", function() {
   it( "should play if a file is added after player disposal if viewer is not paused", function() {
     RiseVision.VideoUtils.setCurrentFiles( [ "url1" ] );
 
-    RiseVision.VideoRLS.play();
+    RiseVision.VideoWatch.play();
     expect( player.init ).to.have.been.calledWith( [ "url1" ] );
     expect( player.init ).to.have.been.called.once;
 
     // this is called after folder is emptied
-    RiseVision.VideoRLS.playerDisposed();
+    RiseVision.VideoWatch.playerDisposed();
 
     // notify the folder has files again
-    RiseVision.VideoRLS.onFileRefresh( [ "url2" ] );
+    RiseVision.VideoWatch.onFileRefresh( [ "url2" ] );
     expect( player.init ).to.have.been.calledWith( [ "url2" ] );
     expect( player.init ).to.have.been.called.twice;
 
     // Cleanup
-    RiseVision.VideoRLS.playerDisposed();
+    RiseVision.VideoWatch.playerDisposed();
   } );
 
   it( "should not play no files are added after player disposal even if viewer is not paused", function() {
     RiseVision.VideoUtils.setCurrentFiles( [ "url1" ] );
 
-    RiseVision.VideoRLS.play();
+    RiseVision.VideoWatch.play();
     expect( player.init ).to.have.been.calledWith( [ "url1" ] );
     expect( player.init ).to.have.been.called.once;
 
     // this is called after folder is emptied
-    RiseVision.VideoRLS.playerDisposed();
+    RiseVision.VideoWatch.playerDisposed();
 
     // notify the folder still has no files
-    RiseVision.VideoRLS.onFileRefresh( [] );
+    RiseVision.VideoWatch.onFileRefresh( [] );
     expect( player.init ).to.have.been.called.once;
   } );
 


### PR DESCRIPTION
## Description
Refactored the decision flow for initiating the appropriate path of functionality with priority to Rise Content Sentinel

Refactored/renamed code usage of term "RLS" with generic "Watch" to account for Content Sentinel

Add new files to facilitate watching files and folders via content sentinel

Conditionally instantiate RLS or Sentinel watch handling

## Motivation and Context
Video caches to browser and shared schedules support video

## How Has This Been Tested?
Staged version of Viewer (stage-2) to support Video Widget in shared schedule and tested this schedule - https://widgets.risevision.com/viewer-stage-2/?type=sharedschedule&id=822cbbd2-ad76-44c1-acc6-cff355e1c133

Further validation:
- Rise Player, 
  - validate RLS used for storage file/folder and widget works as expected
  - validate no impact to custom file and use of Rise Cache
- Legacy Preview, validate working as expected using storage component and requesting to GCS directly

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
