### PR TITLE
Use latest release of common-component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2689,7 +2689,7 @@
       "optional": true
     },
     "common-component": {
-      "version": "git://github.com/Rise-Vision/common-component.git#b260db08994949c5ec09a84f47849f8809bcd7cb",
+      "version": "git://github.com/Rise-Vision/common-component.git#a1af11a94aacecec0f3df683543dbe8fccdad3b2",
       "dev": true
     },
     "component-bind": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bower": "^1.5.3",
     "chai": "^2.1.2",
     "chai-as-promised": "^4.3.0",
-    "common-component": "git://github.com/Rise-Vision/common-component.git#b260db0",
+    "common-component": "git://github.com/Rise-Vision/common-component.git#v1.18.0",
     "del": "~1.1.1",
     "eslint": "^3.8.1",
     "eslint-config-idiomatic": "^2.1.0",


### PR DESCRIPTION
## Description
Use `v1.18.0` of common-component

## Motivation and Context
PR #282 was pointing to latest commit version and not a release tag

## How Has This Been Tested?
Staged version of widget

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
