### PR TITLE
Differentiate file error code for RLS and Content Sentinel

### DIFF
--- a/src/widget/player-local-storage-file.js
+++ b/src/widget/player-local-storage-file.js
@@ -143,7 +143,8 @@ RiseVision.VideoWatch.PlayerLocalStorageFile = function() {
         "event": "error",
         "event_details": msg + ( detail ? " | " + detail : "" ),
         "file_url": data.filePath
-      };
+      },
+      errorCode = msg && msg.toLowerCase().includes( "insufficient disk space" ) ? "E000000040" : "E000000027";
 
     // prevent repetitive logging when widget is receiving messages from other potential widget instances watching same file
     if ( _.isEqual( params, fileErrorLogParams ) ) {
@@ -151,7 +152,7 @@ RiseVision.VideoWatch.PlayerLocalStorageFile = function() {
     }
 
     fileErrorLogParams = _.clone( params );
-    videoUtils.logEvent( params, { severity: "error", errorCode: "E000000027", debugInfo: JSON.stringify( { file_url: params.file_url } ) } );
+    videoUtils.logEvent( params, { severity: "error", errorCode: errorCode, debugInfo: JSON.stringify( { watchType: "rise-local-storage", file_url: params.file_url } ) } );
 
     /*** Possible error messages from Local Storage ***/
     /*

--- a/src/widget/player-local-storage-folder.js
+++ b/src/widget/player-local-storage-folder.js
@@ -288,7 +288,8 @@ RiseVision.VideoWatch.PlayerLocalStorageFolder = function() {
         "event_details": msg + ( detail ? " | " + detail : "" ),
         "file_url": data.filePath
       },
-      fileInError = _getFileInError( data.filePath );
+      fileInError = _getFileInError( data.filePath ),
+      errorCode = msg && msg.toLowerCase().includes( "insufficient disk space" ) ? "E000000040" : "E000000027";
 
     // prevent repetitive logging when widget is receiving messages from other potential widget instances watching same file
     if ( fileInError && _.isEqual( params, fileInError.params ) ) {
@@ -313,7 +314,7 @@ RiseVision.VideoWatch.PlayerLocalStorageFolder = function() {
       "Invalid response with status code [CODE]"
      */
 
-    videoUtils.logEvent( params, { severity: "error", errorCode: "E000000027", debugInfo: JSON.stringify( { file_url: params.file_url } ) } );
+    videoUtils.logEvent( params, { severity: "error", errorCode: errorCode, debugInfo: JSON.stringify( { watchType: "rise-local-storage", file_url: params.file_url } ) } );
 
     if ( !initialLoad && !initialProcessingTimer ) {
       if ( _getFile( data.filePath ) ) {

--- a/src/widget/rise-content-sentinel-file.js
+++ b/src/widget/rise-content-sentinel-file.js
@@ -92,7 +92,8 @@ RiseVision.VideoWatch.RiseContentSentinelFile = function() {
         "event": "error",
         "event_details": msg + ( detail ? " | " + detail : "" ),
         "file_url": data.filePath
-      };
+      },
+      errorCode = msg && msg.toLowerCase().includes( "insufficient disk space" ) ? "E000000040" : "E000000215";
 
     // prevent repetitive logging when widget is receiving messages from other potential widget instances watching same file
     if ( _.isEqual( params, fileErrorLogParams ) ) {
@@ -100,7 +101,7 @@ RiseVision.VideoWatch.RiseContentSentinelFile = function() {
     }
 
     fileErrorLogParams = _.clone( params );
-    videoUtils.logEvent( params, { severity: "error", errorCode: "E000000027", debugInfo: JSON.stringify( { file_url: params.file_url } ) } );
+    videoUtils.logEvent( params, { severity: "error", errorCode: errorCode, debugInfo: JSON.stringify( { watchType: "rise-content-sentinel", file_url: params.file_url } ) } );
 
     RiseVision.VideoWatch.handleError();
   }

--- a/src/widget/rise-content-sentinel-folder.js
+++ b/src/widget/rise-content-sentinel-folder.js
@@ -233,7 +233,8 @@ RiseVision.VideoWatch.RiseContentSentinelFolder = function() {
         "event_details": msg + ( detail ? " | " + detail : "" ),
         "file_url": data.filePath
       },
-      fileInError = _getFileInError( data.filePath );
+      fileInError = _getFileInError( data.filePath ),
+      errorCode = msg && msg.toLowerCase().includes( "insufficient disk space" ) ? "E000000040" : "E000000215";
 
     // prevent repetitive logging when widget is receiving messages from other potential widget instances watching same file
     if ( fileInError && _.isEqual( params, fileInError.params ) ) {
@@ -245,7 +246,7 @@ RiseVision.VideoWatch.RiseContentSentinelFolder = function() {
       params: _.clone( params )
     } );
 
-    videoUtils.logEvent( params, { severity: "error", errorCode: "E000000027", debugInfo: JSON.stringify( { file_url: params.file_url } ) } );
+    videoUtils.logEvent( params, { severity: "error", errorCode: errorCode, debugInfo: JSON.stringify( { watchType: "rise-content-sentinel", file_url: params.file_url } ) } );
 
     if ( !initialLoad && !initialProcessingTimer ) {
       if ( _getFile( data.filePath ) ) {

--- a/test/index.html
+++ b/test/index.html
@@ -39,6 +39,8 @@
     "integration/player-local-storage/messaging-folder.html",
     "integration/rise-content-sentinel/file.html",
     "integration/rise-content-sentinel/folder.html",
+    "integration/rise-content-sentinel/logging-file.html",
+    "integration/rise-content-sentinel/logging-folder.html"
   ]);
 </script>
 </body>

--- a/test/integration/js/player-local-storage-logging-file.js
+++ b/test/integration/js/player-local-storage-logging-file.js
@@ -205,6 +205,7 @@ suite( "errors", function() {
       errorCode: "E000000027",
       eventApp: "widget-video",
       debugInfo: JSON.stringify( {
+        "watchType": "rise-local-storage",
         "file_url": params.file_url
       } )
     } ) );

--- a/test/integration/js/player-local-storage-logging-folder.js
+++ b/test/integration/js/player-local-storage-logging-folder.js
@@ -180,6 +180,7 @@ suite( "errors", function() {
       errorCode: "E000000027",
       eventApp: "widget-video",
       debugInfo: JSON.stringify( {
+        "watchType": "rise-local-storage",
         "file_url": logParams.file_url
       } )
     } ) );

--- a/test/integration/js/rise-content-sentinel-file.js
+++ b/test/integration/js/rise-content-sentinel-file.js
@@ -6,7 +6,7 @@
 var receivedCounter = 0,
   receivedExpected = 0,
   callback = null,
-  receivedHandler = function() {
+  receivedHandler = function(event) {
     if ( event.data.topic.indexOf( "FILE-" ) !== -1 ) {
       receivedCounter += 1;
 
@@ -16,8 +16,8 @@ var receivedCounter = 0,
     }
   };
 
-window.addEventListener( "message", function() {
-  receivedHandler();
+window.addEventListener( "message", function(evt) {
+  receivedHandler(evt);
 } );
 
 suite( "file added", function() {

--- a/test/integration/js/rise-content-sentinel-file.js
+++ b/test/integration/js/rise-content-sentinel-file.js
@@ -6,7 +6,7 @@
 var receivedCounter = 0,
   receivedExpected = 0,
   callback = null,
-  receivedHandler = function(event) {
+  receivedHandler = function( event ) {
     if ( event.data.topic.indexOf( "FILE-" ) !== -1 ) {
       receivedCounter += 1;
 
@@ -16,8 +16,8 @@ var receivedCounter = 0,
     }
   };
 
-window.addEventListener( "message", function(evt) {
-  receivedHandler(evt);
+window.addEventListener( "message", function( evt ) {
+  receivedHandler( evt );
 } );
 
 suite( "file added", function() {

--- a/test/integration/js/rise-content-sentinel-folder.js
+++ b/test/integration/js/rise-content-sentinel-folder.js
@@ -6,7 +6,7 @@
 var receivedCounter = 0,
   receivedExpected = 0,
   callback = null,
-  receivedHandler = function() {
+  receivedHandler = function(event) {
     if ( event.data.topic.indexOf( "FILE-" ) !== -1 ) {
       receivedCounter += 1;
 
@@ -16,8 +16,8 @@ var receivedCounter = 0,
     }
   };
 
-window.addEventListener( "message", function() {
-  receivedHandler();
+window.addEventListener( "message", function(evt) {
+  receivedHandler(evt);
 } );
 
 

--- a/test/integration/js/rise-content-sentinel-folder.js
+++ b/test/integration/js/rise-content-sentinel-folder.js
@@ -6,7 +6,7 @@
 var receivedCounter = 0,
   receivedExpected = 0,
   callback = null,
-  receivedHandler = function(event) {
+  receivedHandler = function( event ) {
     if ( event.data.topic.indexOf( "FILE-" ) !== -1 ) {
       receivedCounter += 1;
 
@@ -16,8 +16,8 @@ var receivedCounter = 0,
     }
   };
 
-window.addEventListener( "message", function(evt) {
-  receivedHandler(evt);
+window.addEventListener( "message", function( evt ) {
+  receivedHandler( evt );
 } );
 
 

--- a/test/integration/js/rise-content-sentinel-logging-file.js
+++ b/test/integration/js/rise-content-sentinel-logging-file.js
@@ -1,4 +1,4 @@
-/* global suiteSetup, suite, setup, teardown, test, assert,
+/* global suiteSetup, suite, test, assert, logSpy,
  RiseVision, sinon */
 
 /* eslint-disable func-names */
@@ -17,7 +17,7 @@ var table = "video_v2_events",
   receivedCounter = 0,
   receivedExpected = 0,
   callback = null,
-  receivedHandler = function(event) {
+  receivedHandler = function( event ) {
     if ( event.data.topic.indexOf( "FILE-" ) !== -1 ) {
       receivedCounter += 1;
 
@@ -27,17 +27,13 @@ var table = "video_v2_events",
     }
   };
 
-window.addEventListener( "message", function(evt) {
-  receivedHandler(evt);
-} );
-
-teardown( function() {
-  logSpy.restore();
+window.addEventListener( "message", function( evt ) {
+  receivedHandler( evt );
 } );
 
 suite( "errors", function() {
 
-  suiteSetup(function(done) {
+  suiteSetup( function( done ) {
     sinon.stub( RiseVision.VideoWatch, "play" );
 
     receivedExpected = 2;
@@ -56,13 +52,14 @@ suite( "errors", function() {
       msg: "File's host server could not be reached",
       detail: "error details"
     }, "*" );
-  })
+  } )
 
   test( "file error", function() {
     params.event = "error";
     params.event_details = "File's host server could not be reached | error details";
 
-    assert.equal(logSpy.callCount, 2); // configuration event and one error event
+    // configuration event and one error event
+    assert.equal( logSpy.callCount, 2 );
     assert( logSpy.calledWith( table, params, {
       severity: "error",
       errorCode: "E000000215",

--- a/test/integration/js/rise-content-sentinel-logging-file.js
+++ b/test/integration/js/rise-content-sentinel-logging-file.js
@@ -1,0 +1,76 @@
+/* global suiteSetup, suite, setup, teardown, test, assert,
+ RiseVision, sinon */
+
+/* eslint-disable func-names */
+
+var table = "video_v2_events",
+  params = {
+    "event": "error",
+    "event_details": "",
+    "file_url": "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/a_food_show.webm",
+    "file_format": "webm",
+    "configuration": "storage file (sentinel)",
+    "company_id": "\"companyId\"",
+    "display_id": "\"displayId\"",
+    "version": "1.1.0"
+  },
+  receivedCounter = 0,
+  receivedExpected = 0,
+  callback = null,
+  receivedHandler = function(event) {
+    if ( event.data.topic.indexOf( "FILE-" ) !== -1 ) {
+      receivedCounter += 1;
+
+      if ( receivedCounter === receivedExpected ) {
+        callback && callback();
+      }
+    }
+  };
+
+window.addEventListener( "message", function(evt) {
+  receivedHandler(evt);
+} );
+
+teardown( function() {
+  logSpy.restore();
+} );
+
+suite( "errors", function() {
+
+  suiteSetup(function(done) {
+    sinon.stub( RiseVision.VideoWatch, "play" );
+
+    receivedExpected = 2;
+    callback = done;
+
+    window.postMessage( {
+      topic: "FILE-ERROR",
+      filePath: params.file_url,
+      msg: "File's host server could not be reached",
+      detail: "error details"
+    }, "*" );
+
+    window.postMessage( {
+      topic: "FILE-ERROR",
+      filePath: params.file_url,
+      msg: "File's host server could not be reached",
+      detail: "error details"
+    }, "*" );
+  })
+
+  test( "file error", function() {
+    params.event = "error";
+    params.event_details = "File's host server could not be reached | error details";
+
+    assert.equal(logSpy.callCount, 2); // configuration event and one error event
+    assert( logSpy.calledWith( table, params, {
+      severity: "error",
+      errorCode: "E000000215",
+      eventApp: "widget-video",
+      debugInfo: JSON.stringify( {
+        "watchType": "rise-content-sentinel",
+        "file_url": params.file_url
+      } )
+    } ) );
+  } );
+} );

--- a/test/integration/js/rise-content-sentinel-logging-folder.js
+++ b/test/integration/js/rise-content-sentinel-logging-folder.js
@@ -1,4 +1,4 @@
-/* global suiteSetup, suite, setup, teardown, test, assert,
+/* global suiteSetup, suite, test, assert, logSpy,
  RiseVision, sinon */
 
 /* eslint-disable func-names */
@@ -17,7 +17,7 @@ var table = "video_v2_events",
   receivedCounter = 0,
   receivedExpected = 0,
   callback = null,
-  receivedHandler = function(event) {
+  receivedHandler = function( event ) {
     if ( event.data.topic.indexOf( "FILE-" ) !== -1 ) {
       receivedCounter += 1;
 
@@ -27,23 +27,17 @@ var table = "video_v2_events",
     }
   };
 
-window.addEventListener( "message", function(evt) {
-  receivedHandler(evt);
-} );
-
-teardown( function() {
-  logSpy.restore();
+window.addEventListener( "message", function( evt ) {
+  receivedHandler( evt );
 } );
 
 suite( "errors", function() {
 
-  suiteSetup(function(done) {
+  suiteSetup( function( done ) {
     sinon.stub( RiseVision.VideoWatch, "play" );
 
     receivedExpected = 1;
     callback = done;
-
-    console.log("posting message")
 
     window.postMessage( {
       topic: "FILE-ERROR",
@@ -51,7 +45,7 @@ suite( "errors", function() {
       msg: "Could not retrieve signed URL",
       detail: "error details"
     }, "*" );
-  })
+  } )
 
   test( "file error", function() {
     var logParams;
@@ -62,7 +56,8 @@ suite( "errors", function() {
     logParams.event = "error";
     logParams.event_details = "Could not retrieve signed URL | error details";
 
-    assert( logSpy.calledTwice ); // once for configuration event and once for error
+    // once for configuration event and once for error
+    assert( logSpy.calledTwice );
     assert( logSpy.calledWith( table, logParams, {
       severity: "error",
       errorCode: "E000000215",

--- a/test/integration/js/rise-content-sentinel-logging-folder.js
+++ b/test/integration/js/rise-content-sentinel-logging-folder.js
@@ -1,0 +1,76 @@
+/* global suiteSetup, suite, setup, teardown, test, assert,
+ RiseVision, sinon */
+
+/* eslint-disable func-names */
+
+var table = "video_v2_events",
+  params = {
+    "event": "error",
+    "event_details": "",
+    "file_url": "risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets/videos/",
+    "file_format": "unknown",
+    "configuration": "storage folder (sentinel)",
+    "company_id": "\"companyId\"",
+    "display_id": "\"displayId\"",
+    "version": "1.1.0"
+  },
+  receivedCounter = 0,
+  receivedExpected = 0,
+  callback = null,
+  receivedHandler = function(event) {
+    if ( event.data.topic.indexOf( "FILE-" ) !== -1 ) {
+      receivedCounter += 1;
+
+      if ( receivedCounter === receivedExpected ) {
+        callback && callback();
+      }
+    }
+  };
+
+window.addEventListener( "message", function(evt) {
+  receivedHandler(evt);
+} );
+
+teardown( function() {
+  logSpy.restore();
+} );
+
+suite( "errors", function() {
+
+  suiteSetup(function(done) {
+    sinon.stub( RiseVision.VideoWatch, "play" );
+
+    receivedExpected = 1;
+    callback = done;
+
+    console.log("posting message")
+
+    window.postMessage( {
+      topic: "FILE-ERROR",
+      filePath: params.file_url + "test-file-in-error.webm",
+      msg: "Could not retrieve signed URL",
+      detail: "error details"
+    }, "*" );
+  })
+
+  test( "file error", function() {
+    var logParams;
+
+    logParams = JSON.parse( JSON.stringify( params ) );
+    logParams.file_url = params.file_url + "test-file-in-error.webm";
+    logParams.file_format = "webm";
+    logParams.event = "error";
+    logParams.event_details = "Could not retrieve signed URL | error details";
+
+    assert( logSpy.calledTwice ); // once for configuration event and once for error
+    assert( logSpy.calledWith( table, logParams, {
+      severity: "error",
+      errorCode: "E000000215",
+      eventApp: "widget-video",
+      debugInfo: JSON.stringify( {
+        "watchType": "rise-content-sentinel",
+        "file_url": logParams.file_url
+      } )
+    } ) );
+  } );
+} );

--- a/test/integration/rise-content-sentinel/logging-file.html
+++ b/test/integration/rise-content-sentinel/logging-file.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Video Widget</title>
+
+  <script src="../../../src/components/web-component-tester/browser.js"></script>
+
+  <link rel="stylesheet" type="text/css" href="../../../src/components/videojs/dist/video-js.css">
+  <link rel="stylesheet" type="text/css" href="../../../src/widget/css/video.css">
+  <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
+</head>
+<body>
+
+<div id="container">
+  <video id="player" class="video-js" preload="auto"></video>
+</div>
+
+<div id="messageContainer"></div>
+
+<script src="../../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
+<script src="../../../node_modules/widget-tester/mocks/logger-mock.js"></script>
+
+<script src="../../../src/components/videojs/dist/video.min.js"></script>
+<script src="../../../src/components/underscore/underscore-min.js"></script>
+
+<script src="../../../src/components/widget-common/dist/config.js"></script>
+<script src="../../../src/components/widget-common/dist/common.js"></script>
+<script src="../../../src/common-modules/rise-content-sentinel.js"></script>
+<script src="../../../src/components/widget-common/dist/message.js"></script>
+<script src="../../../src/config/version.js"></script>
+<script src="../../../src/config/test.js"></script>
+<script src="../../../src/widget/video-utils.js"></script>
+<script src="../../../src/widget/video-watch.js"></script>
+<script src="../../../src/widget/player-utils.js"></script>
+<script src="../../../src/widget/player-vjs.js"></script>
+<script src="../../../src/widget/rise-content-sentinel-file.js"></script>
+
+<script type="text/javascript">
+  config.COMPONENTS_PATH = "../../../src/components/";
+</script>
+
+<script src="../../data/storage-file.js"></script>
+<script src="../js/rise-content-sentinel-logging-file.js"></script>
+<script src="../js/rise-content-sentinel-stubs.js"></script>
+<script src="../../../src/widget/main.js"></script>
+
+</body>
+</html>

--- a/test/integration/rise-content-sentinel/logging-folder.html
+++ b/test/integration/rise-content-sentinel/logging-folder.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Video Widget</title>
+
+  <script src="../../../src/components/web-component-tester/browser.js"></script>
+
+  <link rel="stylesheet" type="text/css" href="../../../src/components/videojs/dist/video-js.css">
+  <link rel="stylesheet" type="text/css" href="../../../src/widget/css/video.css">
+  <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
+</head>
+<body>
+
+<div id="container">
+  <video id="player" class="video-js" preload="auto"></video>
+</div>
+
+<div id="messageContainer"></div>
+
+<script src="../../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
+<script src="../../../node_modules/widget-tester/mocks/logger-mock.js"></script>
+
+<script src="../../../src/components/videojs/dist/video.min.js"></script>
+<script src="../../../src/components/underscore/underscore-min.js"></script>
+
+<script src="../../../src/components/widget-common/dist/config.js"></script>
+<script src="../../../src/components/widget-common/dist/common.js"></script>
+<script src="../../../src/common-modules/rise-content-sentinel.js"></script>
+<script src="../../../src/components/widget-common/dist/message.js"></script>
+<script src="../../../src/config/version.js"></script>
+<script src="../../../src/config/test.js"></script>
+<script src="../../../src/widget/video-utils.js"></script>
+<script src="../../../src/widget/video-watch.js"></script>
+<script src="../../../src/widget/player-utils.js"></script>
+<script src="../../../src/widget/player-vjs.js"></script>
+<script src="../../../src/widget/rise-content-sentinel-folder.js"></script>
+
+<script type="text/javascript">
+  config.COMPONENTS_PATH = "../../../src/components/";
+</script>
+
+<script src="../../data/storage-folder.js"></script>
+<script src="../js/rise-content-sentinel-logging-folder.js"></script>
+<script src="../js/rise-content-sentinel-stubs.js"></script>
+<script src="../../../src/widget/main.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
## Description
Using new `E000000215` code for a file error when using content sentinel and continuing to use `E000000027` specifically for RLS

Also now ensuring to check if file error message is associated with "insufficient disk space" and if so logging with error code `E000000040`. 

Including the `watchType` as additional debug info

## Motivation and Context
Logs are indicating `E000000027` is being reported from endpoints where RLS would not be running therefore adding confusion to investigation and what is defined in Error Definitions for `E000000027`

## How Has This Been Tested?
Staged version of widget in this presentation https://apps.risevision.com/editor/workspace/d6ad8a54-16b9-4ae8-a04e-1ddfbb058a4a?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f 

Tested shared schedules with stage-2 of Viewer (support video widget)
Tested Player

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
