### PR TITLE
Prevent processing logs to client-side-events

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,7 @@
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.15.1",
     "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#2.2.1",
     "videojs": "5.11.9",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.13.1",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.14.0",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#v3.5.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
     "underscore": "~1.8.3",


### PR DESCRIPTION
## Description
Prevent the flow of processing sending logs to client-side-events project by using latest widget-common. See https://github.com/Rise-Vision/common-template/pull/203 for changes. 

## Motivation and Context
https://github.com/Rise-Vision/widget-common/issues/168

## How Has This Been Tested?
Tested using Charles Proxy to map to local version of common-template and config-prod and ran a schedule on ChrOS player. Validated no logs to `Display_Events.events` were inserted. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
no
